### PR TITLE
address threeten transitive vulnerability

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=0.2.0
+projectVersion=0.2.1-SNAPSHOT
 projectGroup=io.micronaut.langchain4j
 
 title=Micronaut LangChain4j

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,14 +38,19 @@ awaitility = "4.2.2"
 #TODO remove when non vulnerable versions exists
 commons-compress = "1.27.1"
 org-json = "20250107"
+threetenbp = "1.7.0"
 
 # Managed versions appear in the BOM
 managed-langchain4j = "1.0.0-alpha1"
 sonatype-scan = "3.0.0"
 
 [libraries]
+# TODO Remove when non vulnerable versions exist
 org-json = { module = 'org.json:json', version.ref = 'org-json'  }
 commons-compress = { module = 'org.apache.commons:commons-compress', version.ref = 'commons-compress'  }
+threetenbp = { module = 'org.threeten:threetenbp', version.ref = 'threetenbp'}
+
+# Micronaut BOMS
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut'  }
 micronaut-redis = { module = 'io.micronaut.redis:micronaut-redis-bom', version.ref = 'micronaut-redis' }
 micronaut-grpc = { module = 'io.micronaut.grpc:micronaut-grpc-bom', version.ref = 'micronaut-grpc' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@
 # a managed version (a version which alias starts with "managed-"
 
 [versions]
-micronaut = "4.7.12"
+micronaut = "4.7.14"
 micronaut-platform = "4.7.4"
 micronaut-docs = "2.0.0"
 micronaut-mongodb = "5.4.0"

--- a/micronaut-langchain4j-vertexai-gemini/build.gradle.kts
+++ b/micronaut-langchain4j-vertexai-gemini/build.gradle.kts
@@ -4,9 +4,10 @@ plugins {
 
 dependencies {
     implementation(libs.langchain4j.vertex.ai.gemini)
-    // apply com.google.protobuf:protobuf-java directly because the version brought transitively contains a vulnerable version.
-    implementation(mnGrpc.protobuf.java)
-
     // TODO: remove when non-vulnerable version released
-    runtimeOnly(libs.threetenbp)
+    constraints {
+        // apply com.google.protobuf:protobuf-java directly because the version brought transitively contains a vulnerable version.
+        implementation(mnGrpc.protobuf.java)
+        implementation(libs.threetenbp)
+    }
 }

--- a/micronaut-langchain4j-vertexai-gemini/build.gradle.kts
+++ b/micronaut-langchain4j-vertexai-gemini/build.gradle.kts
@@ -5,9 +5,7 @@ plugins {
 dependencies {
     implementation(libs.langchain4j.vertex.ai.gemini)
     // TODO: remove when non-vulnerable version released
-    constraints {
-        // apply com.google.protobuf:protobuf-java directly because the version brought transitively contains a vulnerable version.
-        implementation(mnGrpc.protobuf.java)
-        implementation(libs.threetenbp)
-    }
+    // apply com.google.protobuf:protobuf-java directly because the version brought transitively contains a vulnerable version.
+    runtimeOnly(mnGrpc.protobuf.java)
+    runtimeOnly(libs.threetenbp)
 }

--- a/micronaut-langchain4j-vertexai-gemini/build.gradle.kts
+++ b/micronaut-langchain4j-vertexai-gemini/build.gradle.kts
@@ -4,5 +4,9 @@ plugins {
 
 dependencies {
     implementation(libs.langchain4j.vertex.ai.gemini)
-    implementation(mnGrpc.protobuf.java) // apply com.google.protobuf:protobuf-java directly because the version brought transitively contains a vulnerable version.
+    // apply com.google.protobuf:protobuf-java directly because the version brought transitively contains a vulnerable version.
+    implementation(mnGrpc.protobuf.java)
+
+    // TODO: remove when non-vulnerable version released
+    runtimeOnly(libs.threetenbp)
 }

--- a/micronaut-langchain4j-vertexai/build.gradle.kts
+++ b/micronaut-langchain4j-vertexai/build.gradle.kts
@@ -5,9 +5,7 @@ plugins {
 dependencies {
     implementation(libs.langchain4j.vertex.ai)
     // TODO: remove when non-vulnerable version released
-    constraints {
-        // apply com.google.protobuf:protobuf-java directly because the version brought transitively contains a vulnerable version.
-        implementation(mnGrpc.protobuf.java)
-        implementation(libs.threetenbp)
-    }
+    // apply com.google.protobuf:protobuf-java directly because the version brought transitively contains a vulnerable version.
+    runtimeOnly(mnGrpc.protobuf.java)
+    runtimeOnly(libs.threetenbp)
 }

--- a/micronaut-langchain4j-vertexai/build.gradle.kts
+++ b/micronaut-langchain4j-vertexai/build.gradle.kts
@@ -4,5 +4,9 @@ plugins {
 
 dependencies {
     implementation(libs.langchain4j.vertex.ai)
-    implementation(mnGrpc.protobuf.java) // apply com.google.protobuf:protobuf-java directly because the version brought transitively contains a vulnerable version.
+    // apply com.google.protobuf:protobuf-java directly because the version brought transitively contains a vulnerable version.
+    implementation(mnGrpc.protobuf.java)
+
+    // TODO: remove when non-vulnerable version released
+    runtimeOnly(libs.threetenbp)
 }

--- a/micronaut-langchain4j-vertexai/build.gradle.kts
+++ b/micronaut-langchain4j-vertexai/build.gradle.kts
@@ -4,9 +4,10 @@ plugins {
 
 dependencies {
     implementation(libs.langchain4j.vertex.ai)
-    // apply com.google.protobuf:protobuf-java directly because the version brought transitively contains a vulnerable version.
-    implementation(mnGrpc.protobuf.java)
-
     // TODO: remove when non-vulnerable version released
-    runtimeOnly(libs.threetenbp)
+    constraints {
+        // apply com.google.protobuf:protobuf-java directly because the version brought transitively contains a vulnerable version.
+        implementation(mnGrpc.protobuf.java)
+        implementation(libs.threetenbp)
+    }
 }


### PR DESCRIPTION
Google's AI libraries transitively pull vulnerable versions of threeten which is failing the build