### PR TITLE
Fix vulnerability with Jinjava

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ awaitility = "4.3.0"
 commons-compress = "1.27.1"
 commons-lang3 = "3.18.0"
 gson = "2.12.0"
+jinjava = "2.8.1"
 
 # Managed versions appear in the BOM
 managed-langchain4j = "1.5.0"
@@ -56,6 +57,7 @@ astra-db-client = "1.2.7"
 commons-compress = { module = 'org.apache.commons:commons-compress', version.ref = 'commons-compress'  }
 commons-lang3 = { module = 'org.apache.commons:commons-lang3', version.ref = 'commons-lang3' }
 gson = { module = 'com.google.code.gson:gson', version.ref = 'gson' }
+jinjava = { module = "com.hubspot.jinjava:jinjava", version.ref = "jinjava"}
 
 # Micronaut BOMS
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut'  }
@@ -117,4 +119,3 @@ sonatype-scan = { module = "org.sonatype.gradle.plugins:scan-gradle-plugin", ver
 [bundles]
 
 [plugins]
-

--- a/micronaut-langchain4j-jlama/build.gradle.kts
+++ b/micronaut-langchain4j-jlama/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
 dependencies {
     api(libs.langchain4j.jlama)
     implementation(libs.commons.lang3) // versions prior to 3.18.0 contains a CVE https://ossindex.sonatype.org/component/pkg:maven/org.apache.commons/commons-lang3
+    implementation(libs.jinjava) {
+        because("jinjava releases prior to 2.8.1 are vulnerable")
+    }
 }
 
 micronautBuild {


### PR DESCRIPTION
jinjava is a transitive dependency, so we workaround by adding a direct dependency (we could use a constraint but it wouldn't work with Maven unfortunately!).
