### PR TITLE
Use MemoryStoreProvider for `@AiService`

### DIFF
--- a/micronaut-langchain4j-core/src/main/java/io/micronaut/langchain4j/aiservices/AiServiceFactory.java
+++ b/micronaut-langchain4j-core/src/main/java/io/micronaut/langchain4j/aiservices/AiServiceFactory.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.langchain4j.aiservices;
 
-import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
@@ -23,7 +23,6 @@ import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.store.embedding.EmbeddingStore;
-import dev.langchain4j.store.memory.chat.InMemoryChatMemoryStore;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanProvider;
 import io.micronaut.context.Qualifier;
@@ -90,13 +89,7 @@ public class AiServiceFactory {
 
         lookupByNameOrDefault(name, ModerationModel.class, builder::moderationModel);
 
-        // default to in-memory chat store, but allow replacement
-        lookupByNameOrDefault(name, InMemoryChatMemoryStore.class, new InMemoryChatMemoryStore(), (store) -> builder.chatMemory(
-            MessageWindowChatMemory.builder()
-                .maxMessages(10)
-                .chatMemoryStore(store)
-                .build()
-        ));
+        lookupByNameOrDefault(name, ChatMemoryProvider.class, builder::chatMemoryProvider);
 
         lookupByNameOrDefault(name, EmbeddingModel.class, null, embeddingModel ->
             lookupByNameOrDefault(name, EmbeddingStore.class, null, embeddingStore ->

--- a/micronaut-langchain4j-core/src/main/java/io/micronaut/langchain4j/store/memory/chat/MessageWindowChatMemoryFactory.java
+++ b/micronaut-langchain4j-core/src/main/java/io/micronaut/langchain4j/store/memory/chat/MessageWindowChatMemoryFactory.java
@@ -29,8 +29,7 @@ import io.micronaut.core.annotation.NonNull;
  */
 @Factory
 @Internal
-
-class MessageWindowChatMemoryFactory {
+public class MessageWindowChatMemoryFactory {
 
     /**
      *
@@ -40,8 +39,8 @@ class MessageWindowChatMemoryFactory {
     @Prototype
     @EachBean(ChatMemoryStore.class)
     @NonNull
-    MessageWindowChatMemory.Builder createMessageWindowChatMemoryBuilder(@NonNull ChatMemoryStore chatMemoryStore,
-                                                                         @NonNull MessageWindowChatMemoryConfiguration config) {
+    public MessageWindowChatMemory.Builder createMessageWindowChatMemoryBuilder(@NonNull ChatMemoryStore chatMemoryStore,
+                                                                                @NonNull MessageWindowChatMemoryConfiguration config) {
         return MessageWindowChatMemory.builder()
             .maxMessages(config.getMaxMessages())
             .chatMemoryStore(chatMemoryStore);

--- a/micronaut-langchain4j-core/src/main/java/io/micronaut/langchain4j/store/memory/chat/inmemory/InMemoryMessageWindowChatMemoryProvider.java
+++ b/micronaut-langchain4j-core/src/main/java/io/micronaut/langchain4j/store/memory/chat/inmemory/InMemoryMessageWindowChatMemoryProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.langchain4j.store.memory.chat.inmemory;
+
+import dev.langchain4j.Internal;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import io.micronaut.langchain4j.store.memory.chat.MessageWindowChatMemoryConfiguration;
+import io.micronaut.langchain4j.store.memory.chat.MessageWindowChatMemoryFactory;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+/**
+ * {@link ChatMemoryProvider} implementation that creates {@link dev.langchain4j.memory.chat.MessageWindowChatMemory}.
+ */
+@Internal
+@Named("InMemoryMessageWindow")
+@Singleton
+class InMemoryMessageWindowChatMemoryProvider implements ChatMemoryProvider {
+    private final MessageWindowChatMemoryFactory messageWindowChatMemoryFactory;
+    private final InMemoryChatMemoryStoreFactory inMemoryChatMemoryStoreFactory;
+    private final MessageWindowChatMemoryConfiguration config;
+
+    InMemoryMessageWindowChatMemoryProvider(MessageWindowChatMemoryFactory messageWindowChatMemoryFactory,
+                                            InMemoryChatMemoryStoreFactory inMemoryChatMemoryStoreFactory,
+                                            MessageWindowChatMemoryConfiguration config) {
+        this.messageWindowChatMemoryFactory = messageWindowChatMemoryFactory;
+        this.inMemoryChatMemoryStoreFactory = inMemoryChatMemoryStoreFactory;
+        this.config = config;
+    }
+
+    @Override
+    public ChatMemory get(Object memoryId) {
+        ChatMemoryStore chatMemoryStore = inMemoryChatMemoryStoreFactory.chatMemoryStore();
+        return messageWindowChatMemoryFactory.createMessageWindowChatMemoryBuilder(chatMemoryStore, config)
+            .id(memoryId)
+            .build();
+    }
+}

--- a/micronaut-langchain4j-core/src/test/java/io/micronaut/langchain4j/store/memory/chat/inmemory/InMemoryMessageWindowChatMemoryProviderTest.java
+++ b/micronaut-langchain4j-core/src/test/java/io/micronaut/langchain4j/store/memory/chat/inmemory/InMemoryMessageWindowChatMemoryProviderTest.java
@@ -1,0 +1,24 @@
+package io.micronaut.langchain4j.store.memory.chat.inmemory;
+
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import io.micronaut.context.BeanContext;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@MicronautTest(startApplication = false)
+class InMemoryMessageWindowChatMemoryProviderTest {
+
+    @Inject
+    BeanContext beanContext;
+
+    @Test
+    void messageWindowChatMemoryProvider() {
+        ChatMemoryProvider provider = beanContext.getBean(ChatMemoryProvider.class, Qualifiers.byName("InMemoryMessageWindow"));
+        assertNotNull(provider);
+        assertInstanceOf(InMemoryMessageWindowChatMemoryProvider.class, provider);
+    }
+}

--- a/micronaut-langchain4j-openai/src/test/java/io/micronaut/langchain4j/openai/AiServiceMemoryIdTest.java
+++ b/micronaut-langchain4j-openai/src/test/java/io/micronaut/langchain4j/openai/AiServiceMemoryIdTest.java
@@ -1,0 +1,40 @@
+package io.micronaut.langchain4j.openai;
+
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.langchain4j.annotation.AiService;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Property(name = "spec.name", value = "AiServiceMemoryIdTest")
+@MicronautTest(startApplication = false)
+class AiServiceMemoryIdTest {
+
+    @Test
+    void testAiServiceWithMemoryId(Assistant assistant) {
+        String sergioId = UUID.randomUUID().toString();
+        String timId = UUID.randomUUID().toString();
+        assistant.chat(sergioId, "My name is Sergio");
+        assistant.chat(timId, "My name is Tim");
+        String sergioResponse = assistant.chat(sergioId, "Do you remember my name?").toLowerCase(Locale.ROOT);
+        assertTrue(sergioResponse.contains("sergio"));
+        assertFalse(sergioResponse.contains("tim"));
+        String timResponse = assistant.chat(timId, "Do you remember my name?").toLowerCase(Locale.ROOT);
+        assertTrue(timResponse.contains("tim"));
+        assertFalse(timResponse.contains("sergio"));
+    }
+
+    @Requires(property = "spec.name", value = "AiServiceMemoryIdTest")
+    @AiService
+    interface Assistant {
+        String chat(@MemoryId String memoryId, @UserMessage String message);
+    }
+}

--- a/micronaut-langchain4j-openai/src/test/java/io/micronaut/langchain4j/openai/OpenAiAiTest.java
+++ b/micronaut-langchain4j-openai/src/test/java/io/micronaut/langchain4j/openai/OpenAiAiTest.java
@@ -11,7 +11,7 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
-@MicronautTest
+@MicronautTest(startApplication = false)
 @Property(name = "langchain4j.open-ai.api-key", value = "blah")
 @Property(name = "langchain4j.open-ai.organization-id", value = "blah")
 @EnabledIfEnvironmentVariable(

--- a/micronaut-langchain4j-openai/src/test/java/io/micronaut/langchain4j/openai/OpenAiAiTest.java
+++ b/micronaut-langchain4j-openai/src/test/java/io/micronaut/langchain4j/openai/OpenAiAiTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
     named = "LANGCHAIN4J_OPEN_AI_API_KEY",
     matches = "\\.+"
 )
-public class OpenAiAiTest {
+class OpenAiAiTest {
 
     @Inject
     DefaultOpenAiChatModelConfiguration chatLanguageModelConfiguration;

--- a/micronaut-langchain4j-openai/src/test/java/io/micronaut/langchain4j/openai/OpenAiAiTest.java
+++ b/micronaut-langchain4j-openai/src/test/java/io/micronaut/langchain4j/openai/OpenAiAiTest.java
@@ -14,10 +14,6 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 @MicronautTest(startApplication = false)
 @Property(name = "langchain4j.open-ai.api-key", value = "blah")
 @Property(name = "langchain4j.open-ai.organization-id", value = "blah")
-@EnabledIfEnvironmentVariable(
-    named = "LANGCHAIN4J_OPEN_AI_API_KEY",
-    matches = "\\.+"
-)
 class OpenAiAiTest {
 
     @Inject

--- a/test-suite/src/test/java/example/micronaut/aiservice/AiServiceMemoryIdTest.java
+++ b/test-suite/src/test/java/example/micronaut/aiservice/AiServiceMemoryIdTest.java
@@ -1,14 +1,17 @@
-package io.micronaut.langchain4j.openai;
+package example.micronaut.aiservice;
 
 import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.UserMessage;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.langchain4j.annotation.AiService;
+import io.micronaut.langchain4j.testutils.OllamaTestPropertyProvider;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariables;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.Locale;
 import java.util.UUID;
@@ -16,14 +19,11 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnabledIfEnvironmentVariables(value = {
-    @EnabledIfEnvironmentVariable(named = "LANGCHAIN4J_OPEN_AI_API_KEY", matches = "\\.+"),
-    @EnabledIfEnvironmentVariable(named = "LANGCHAIN4J_OPEN_AI_ORGANIZATION_ID", matches = "\\.+"),
-})
 @Property(name = "spec.name", value = "AiServiceMemoryIdTest")
+@Testcontainers(disabledWithoutDocker = true)
 @MicronautTest(startApplication = false)
-class AiServiceMemoryIdTest {
-
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AiServiceMemoryIdTest implements OllamaTestPropertyProvider {
     @Test
     void testAiServiceWithMemoryId(Assistant assistant) {
         String sergioId = UUID.randomUUID().toString();


### PR DESCRIPTION
Close: https://github.com/micronaut-projects/micronaut-langchain4j/issues/234

Previously, we were invoking `builder.chatMemory` which means that you use the same (shared) `ChatMemory` for all users/conversations.
 
`AIServices::chatMemoryProvider` javadoc: 

> If you prefer to use the same (shared) ChatMemory for all users/conversations, configure a chatMemory instead.
> Either a ChatMemory or a ChatMemoryProvider can be configured, but not both simultaneously.

However, using `chatMemory` fails with a `NPE` for such an `@AiService`

```java
 @AiService
    interface Assistant {
        String chat(@MemoryId String memoryId, @UserMessage String message);
 }
 ```

This Pull-Request changes to use `chatMemoryProvider` instead. 