### PR TITLE
expose langchain4j boms with boms-

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.langchain4j-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.langchain4j-module.gradle
@@ -10,8 +10,8 @@ ossIndexAudit {
 
 dependencies {
     annotationProcessor(mn.micronaut.inject.java)
-    api(platform(libs.langchain4j.bom))
-    implementation(platform(libs.langchain4j.bom))
+    api(platform(libs.boms.langchain4j))
+    implementation(platform(libs.boms.langchain4j))
     testAnnotationProcessor(mn.micronaut.inject.java)
     testImplementation(mnTest.micronaut.test.junit5)
     testRuntimeOnly(mnLogging.logback.classic)

--- a/doc-examples/example-java/build.gradle.kts
+++ b/doc-examples/example-java/build.gradle.kts
@@ -12,7 +12,7 @@ micronaut {
     testRuntime("junit5")
 }
 dependencies {
-    implementation(platform(libs.langchain4j.bom))
+    implementation(platform(libs.boms.langchain4j))
     annotationProcessor(projects.micronautLangchain4jProcessor)
     implementation(projects.micronautLangchain4jOllama)
     implementation(mn.micronaut.http.client)

--- a/doc-examples/example-openai-java/build.gradle.kts
+++ b/doc-examples/example-openai-java/build.gradle.kts
@@ -10,7 +10,7 @@ micronaut {
     testRuntime("junit5")
 }
 dependencies {
-    implementation(platform(libs.langchain4j.bom))
+    implementation(platform(libs.boms.langchain4j))
 
     annotationProcessor(projects.micronautLangchain4jProcessor)
     implementation(projects.micronautLangchain4jOpenai)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -113,8 +113,8 @@ junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-bom" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 
 # BOMs
-langchain4j-bom = { module = "dev.langchain4j:langchain4j-bom", version.ref = "managed-langchain4j" }
-langchain4j-community-bom = { module = "dev.langchain4j:langchain4j-community-bom", version.ref = "managed-langchain4j-community" }
+boms-langchain4j = { module = "dev.langchain4j:langchain4j-bom", version.ref = "managed-langchain4j" }
+boms-langchain4j-community = { module = "dev.langchain4j:langchain4j-community-bom", version.ref = "managed-langchain4j-community" }
 
 # Plugins
 gradle-micronaut = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref = "micronaut-gradle-plugin" }

--- a/micronaut-langchain4j-oci-genai/build.gradle.kts
+++ b/micronaut-langchain4j-oci-genai/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api(platform(libs.langchain4j.community.bom))
+    api(platform(libs.boms.langchain4j.community))
     api(platform(mnOraclecloud.micronaut.oraclecloud.bom))
     implementation(libs.langchain4j.oci.genai)
     api(libs.micronaut.oraclecloud.bmc.generativeaiinference)

--- a/micronaut-langchain4j-openai/build.gradle.kts
+++ b/micronaut-langchain4j-openai/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 dependencies {
-    implementation(platform(libs.langchain4j.bom))
+    implementation(platform(libs.boms.langchain4j))
     implementation(libs.langchain4j.open.ai)
 }

--- a/micronaut-langchain4j-store-neo4j/build.gradle.kts
+++ b/micronaut-langchain4j-store-neo4j/build.gradle.kts
@@ -6,7 +6,7 @@ micronaut {
     version.set(libs.versions.micronaut.platform.get())
 }
 dependencies {
-    implementation(platform(libs.langchain4j.community.bom))
+    implementation(platform(libs.boms.langchain4j.community))
     api(mnNeo4j.micronaut.neo4j.bolt)
     implementation(libs.langchain4j.neo4j)
     testImplementation(mnSerde.micronaut.serde.jackson)

--- a/micronaut-langchain4j-store-redis/build.gradle.kts
+++ b/micronaut-langchain4j-store-redis/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api(platform(libs.langchain4j.community.bom))
+    api(platform(libs.boms.langchain4j.community))
     implementation(libs.langchain4j.redis)
     implementation(libs.gson) // versions prior to 2.12.0 contains a CVE https://ossindex.sonatype.org/component/pkg:maven/com.google.code.gson/gson
 }


### PR DESCRIPTION
@graemerocher I don't know if you intentionally omitted the langchain4j BOMs from the first version of `micronaut-langchain4j`. This PR changes the configuration of this module to expose the langchain4j BOMs as we do with other BOMs, such as [open telemetry BOMs](https://github.com/micronaut-projects/micronaut-tracing/blob/8.0.x/gradle/libs.versions.toml#L103-L108)

