### PR TITLE
Fix AI service model selection

### DIFF
--- a/micronaut-langchain4j-core/src/main/java/io/micronaut/langchain4j/aiservices/AiServiceFactory.java
+++ b/micronaut-langchain4j-core/src/main/java/io/micronaut/langchain4j/aiservices/AiServiceFactory.java
@@ -160,7 +160,7 @@ public class AiServiceFactory {
 
     private static boolean isStreamingReturnType(ExecutableMethod<?, ?> method) {
         Argument<?> returnType = method.getReturnType().asArgument();
-        if (returnType.getType() == TokenStream.class) {
+        if (TokenStream.class.isAssignableFrom(returnType.getType())) {
             return true;
         }
         for (TokenStreamAdapter tokenStreamAdapter : TOKEN_STREAM_ADAPTERS) {

--- a/micronaut-langchain4j-core/src/main/java/io/micronaut/langchain4j/aiservices/AiServiceFactory.java
+++ b/micronaut-langchain4j-core/src/main/java/io/micronaut/langchain4j/aiservices/AiServiceFactory.java
@@ -22,6 +22,9 @@ import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
 import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.spi.ServiceHelper;
+import dev.langchain4j.spi.services.TokenStreamAdapter;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanProvider;
@@ -32,8 +35,11 @@ import io.micronaut.context.annotation.Parameter;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.langchain4j.tools.ToolRegistry;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -44,6 +50,7 @@ import java.util.function.Consumer;
  */
 @Factory
 public class AiServiceFactory {
+    private static final Collection<TokenStreamAdapter> TOKEN_STREAM_ADAPTERS = ServiceHelper.loadFactories(TokenStreamAdapter.class);
 
     private final BeanContext beanContext;
     private final ToolRegistry toolRegistry;
@@ -83,9 +90,13 @@ public class AiServiceFactory {
             builder.tools(toolsTyped);
         }
 
-        lookupByNameOrDefault(name, ChatModel.class, builder::chatModel);
-
-        lookupByNameOrDefault(name, StreamingChatModel.class, builder::streamingChatModel);
+        ModelSelection modelSelection = selectModels(serviceDef.beanDefinition());
+        if (modelSelection.chatModel()) {
+            lookupByNameOrDefault(name, ChatModel.class, builder::chatModel);
+        }
+        if (modelSelection.streamingChatModel()) {
+            lookupByNameOrDefault(name, StreamingChatModel.class, builder::streamingChatModel);
+        }
 
         lookupByNameOrDefault(name, ModerationModel.class, builder::moderationModel);
 
@@ -123,5 +134,62 @@ public class AiServiceFactory {
 
         provider.find(qualifier).ifPresentOrElse(configurer,
             () -> provider.ifPresent(configurer));
+    }
+
+    static ModelSelection selectModels(BeanDefinition<?> beanDefinition) {
+        boolean hasStreamingMethods = false;
+        boolean hasNonStreamingMethods = false;
+        for (ExecutableMethod<?, ?> method : beanDefinition.getExecutableMethods()) {
+            if (method.getDeclaringType() == Object.class) {
+                continue;
+            }
+            if (isStreamingReturnType(method)) {
+                hasStreamingMethods = true;
+            } else {
+                hasNonStreamingMethods = true;
+            }
+        }
+        if (!hasStreamingMethods) {
+            return ModelSelection.CHAT;
+        }
+        if (!hasNonStreamingMethods) {
+            return ModelSelection.STREAMING;
+        }
+        return ModelSelection.BOTH;
+    }
+
+    private static boolean isStreamingReturnType(ExecutableMethod<?, ?> method) {
+        Argument<?> returnType = method.getReturnType().asArgument();
+        if (returnType.getType() == TokenStream.class) {
+            return true;
+        }
+        for (TokenStreamAdapter tokenStreamAdapter : TOKEN_STREAM_ADAPTERS) {
+            if (tokenStreamAdapter.canAdaptTokenStreamTo(returnType.getType())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    enum ModelSelection {
+        CHAT(true, false),
+        STREAMING(false, true),
+        BOTH(true, true);
+
+        private final boolean chatModel;
+        private final boolean streamingChatModel;
+
+        ModelSelection(boolean chatModel, boolean streamingChatModel) {
+            this.chatModel = chatModel;
+            this.streamingChatModel = streamingChatModel;
+        }
+
+        boolean chatModel() {
+            return chatModel;
+        }
+
+        boolean streamingChatModel() {
+            return streamingChatModel;
+        }
     }
 }

--- a/micronaut-langchain4j-core/src/test/java/io/micronaut/langchain4j/aiservices/AiServiceFactoryModelSelectionTest.java
+++ b/micronaut-langchain4j-core/src/test/java/io/micronaut/langchain4j/aiservices/AiServiceFactoryModelSelectionTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.langchain4j.aiservices;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.service.TokenStream;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.langchain4j.annotation.AiService;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest(startApplication = false)
+@Property(name = "spec.name", value = AiServiceFactoryModelSelectionTest.SPEC_NAME)
+class AiServiceFactoryModelSelectionTest {
+
+    static final String SPEC_NAME = "AiServiceFactoryModelSelectionTest";
+
+    @Inject
+    BeanContext beanContext;
+
+    @Test
+    void configuresOnlyChatModelForNonStreamingServices(ChatAssistant assistant) {
+        assertEquals("chat-model", assistant.chat("hello"));
+        assertEquals(AiServiceFactory.ModelSelection.CHAT, AiServiceFactory.selectModels(beanContext.getBeanDefinition(ChatAssistant.class)));
+    }
+
+    @Test
+    void configuresOnlyStreamingChatModelForStreamingServices(StreamingAssistant assistant) throws InterruptedException {
+        CountDownLatch completed = new CountDownLatch(1);
+        AtomicReference<String> partialResponse = new AtomicReference<>();
+
+        assistant.chat("hello")
+            .onPartialResponse(partialResponse::set)
+            .onCompleteResponse(ignore -> completed.countDown())
+            .onError(error -> {
+                throw new AssertionError(error);
+            })
+            .start();
+
+        assertTrue(completed.await(5, TimeUnit.SECONDS));
+        assertEquals("streaming-model", partialResponse.get());
+        assertEquals(AiServiceFactory.ModelSelection.STREAMING, AiServiceFactory.selectModels(beanContext.getBeanDefinition(StreamingAssistant.class)));
+    }
+
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    @AiService
+    interface ChatAssistant {
+        String chat(String userMessage);
+    }
+
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    @AiService
+    interface StreamingAssistant {
+        TokenStream chat(String userMessage);
+    }
+
+    @Factory
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static final class TestModelsFactory {
+
+        @Singleton
+        ChatModel chatModel() {
+            return new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest chatRequest) {
+                    return ChatResponse.builder()
+                        .aiMessage(new AiMessage("chat-model"))
+                        .build();
+                }
+            };
+        }
+
+        @Singleton
+        StreamingChatModel streamingChatModel() {
+            return new StreamingChatModel() {
+                @Override
+                public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+                    assertNotNull(chatRequest);
+                    handler.onPartialResponse("streaming-model");
+                    handler.onCompleteResponse(ChatResponse.builder()
+                        .aiMessage(new AiMessage("streaming-model"))
+                        .build());
+                }
+            };
+        }
+    }
+}

--- a/micronaut-langchain4j-core/src/test/java/io/micronaut/langchain4j/aiservices/AiServiceFactoryModelSelectionTest.java
+++ b/micronaut-langchain4j-core/src/test/java/io/micronaut/langchain4j/aiservices/AiServiceFactoryModelSelectionTest.java
@@ -59,18 +59,48 @@ class AiServiceFactoryModelSelectionTest {
     void configuresOnlyStreamingChatModelForStreamingServices(StreamingAssistant assistant) throws InterruptedException {
         CountDownLatch completed = new CountDownLatch(1);
         AtomicReference<String> partialResponse = new AtomicReference<>();
+        AtomicReference<Throwable> errorRef = new AtomicReference<>();
 
         assistant.chat("hello")
             .onPartialResponse(partialResponse::set)
             .onCompleteResponse(ignore -> completed.countDown())
             .onError(error -> {
-                throw new AssertionError(error);
+                errorRef.set(error);
+                completed.countDown();
             })
             .start();
 
         assertTrue(completed.await(5, TimeUnit.SECONDS));
+        if (errorRef.get() != null) {
+            throw new AssertionError(errorRef.get());
+        }
         assertEquals("streaming-model", partialResponse.get());
         assertEquals(AiServiceFactory.ModelSelection.STREAMING, AiServiceFactory.selectModels(beanContext.getBeanDefinition(StreamingAssistant.class)));
+    }
+
+    @Test
+    void configuresBothModelsForMixedServices(MixedAssistant assistant) throws InterruptedException {
+        assertEquals("chat-model", assistant.chat("hello"));
+
+        CountDownLatch completed = new CountDownLatch(1);
+        AtomicReference<String> partialResponse = new AtomicReference<>();
+        AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+        assistant.streamChat("hello")
+            .onPartialResponse(partialResponse::set)
+            .onCompleteResponse(ignore -> completed.countDown())
+            .onError(error -> {
+                errorRef.set(error);
+                completed.countDown();
+            })
+            .start();
+
+        assertTrue(completed.await(5, TimeUnit.SECONDS));
+        if (errorRef.get() != null) {
+            throw new AssertionError(errorRef.get());
+        }
+        assertEquals("streaming-model", partialResponse.get());
+        assertEquals(AiServiceFactory.ModelSelection.BOTH, AiServiceFactory.selectModels(beanContext.getBeanDefinition(MixedAssistant.class)));
     }
 
     @Requires(property = "spec.name", value = SPEC_NAME)
@@ -83,6 +113,13 @@ class AiServiceFactoryModelSelectionTest {
     @AiService
     interface StreamingAssistant {
         TokenStream chat(String userMessage);
+    }
+
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    @AiService
+    interface MixedAssistant {
+        String chat(String userMessage);
+        TokenStream streamChat(String userMessage);
     }
 
     @Factory


### PR DESCRIPTION
## Summary

- configure only the chat model for non-streaming AI services and only the streaming chat model for streaming AI services
- retain support for mixed service interfaces by configuring both models when a bean exposes both return styles
- add regression coverage for chat-only and streaming-only AI service interfaces

## Verification

- `./gradlew :micronaut-langchain4j-core:test --tests io.micronaut.langchain4j.aiservices.AiServiceFactoryModelSelectionTest`

Resolves https://github.com/micronaut-projects/micronaut-langchain4j/issues/233
