### PR TITLE
Fix PGVector store creation with proxied data sources

### DIFF
--- a/micronaut-langchain4j-store-pgvector/src/main/java/io/micronaut/langchain4j/pgvector/PgVectorEmbeddingStoreFactory.java
+++ b/micronaut-langchain4j-store-pgvector/src/main/java/io/micronaut/langchain4j/pgvector/PgVectorEmbeddingStoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,9 @@ import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.jdbc.DataSourceResolver;
+import org.jspecify.annotations.Nullable;
+
 import javax.sql.DataSource;
 
 /**
@@ -29,12 +32,22 @@ import javax.sql.DataSource;
  */
 @Factory
 public class PgVectorEmbeddingStoreFactory {
+    private final @Nullable DataSourceResolver dataSourceResolver;
+
+    public PgVectorEmbeddingStoreFactory(@Nullable DataSourceResolver dataSourceResolver) {
+        this.dataSourceResolver = dataSourceResolver;
+    }
+
     @EachBean(PgVectorEmbeddingStoreConfig.class)
     @Context
     @Bean(typed = EmbeddingStore.class)
     protected PgVectorEmbeddingStore pgVectorEmbeddingStore(PgVectorEmbeddingStoreConfig configuration) {
+        DataSource dataSource = configuration.getDataSource();
+        if (dataSourceResolver != null) {
+            dataSource = dataSourceResolver.resolve(dataSource);
+        }
         return new DataSourcePgVectorStore(
-                configuration.getDataSource(),
+                dataSource,
                 configuration.getTable(),
                 configuration.getDimension(),
                 configuration.getUseIndex(),

--- a/micronaut-langchain4j-store-pgvector/src/main/java/io/micronaut/langchain4j/pgvector/PgVectorEmbeddingStoreFactory.java
+++ b/micronaut-langchain4j-store-pgvector/src/main/java/io/micronaut/langchain4j/pgvector/PgVectorEmbeddingStoreFactory.java
@@ -23,6 +23,7 @@ import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.jdbc.DataSourceResolver;
+import jakarta.inject.Inject;
 import org.jspecify.annotations.Nullable;
 
 import javax.sql.DataSource;
@@ -34,6 +35,11 @@ import javax.sql.DataSource;
 public class PgVectorEmbeddingStoreFactory {
     private final @Nullable DataSourceResolver dataSourceResolver;
 
+    public PgVectorEmbeddingStoreFactory() {
+        this(null);
+    }
+
+    @Inject
     public PgVectorEmbeddingStoreFactory(@Nullable DataSourceResolver dataSourceResolver) {
         this.dataSourceResolver = dataSourceResolver;
     }

--- a/micronaut-langchain4j-store-pgvector/src/test/java/io/micronaut/langchain4j/pgvector/PgVectorEmbeddingStoreFactoryTest.java
+++ b/micronaut-langchain4j-store-pgvector/src/test/java/io/micronaut/langchain4j/pgvector/PgVectorEmbeddingStoreFactoryTest.java
@@ -37,6 +37,20 @@ class PgVectorEmbeddingStoreFactoryTest {
         Assertions.assertNotNull(embeddingStore);
     }
 
+    @Test
+    void supportsConstructionWithoutDataSourceResolver() {
+        PgVectorEmbeddingStoreFactory factory = new PgVectorEmbeddingStoreFactory();
+        PgVectorEmbeddingStoreConfig configuration = new PgVectorEmbeddingStoreConfig(new StubDataSource(false), null);
+        configuration.setTable("test");
+        configuration.setDimension(384);
+        configuration.setCreateTable(false);
+        configuration.setDropTableFirst(false);
+
+        PgVectorEmbeddingStore embeddingStore = factory.pgVectorEmbeddingStore(configuration);
+
+        Assertions.assertNotNull(embeddingStore);
+    }
+
     private static final class StubDataSource implements DataSource {
         private final boolean failOnConnection;
 
@@ -57,7 +71,9 @@ class PgVectorEmbeddingStoreFactoryTest {
                                 Statement.class.getClassLoader(),
                                 new Class<?>[] {Statement.class},
                                 (statementProxy, statementMethod, statementArgs) -> switch (statementMethod.getName()) {
-                                    case "execute", "executeUpdate", "close" -> null;
+                                    case "execute" -> false;
+                                    case "executeUpdate" -> 0;
+                                    case "close" -> null;
                                     case "getConnection" -> proxy;
                                     case "unwrap" -> statementArgs[0] == Statement.class ? statementProxy : null;
                                     case "isWrapperFor" -> statementArgs[0] == Statement.class;

--- a/micronaut-langchain4j-store-pgvector/src/test/java/io/micronaut/langchain4j/pgvector/PgVectorEmbeddingStoreFactoryTest.java
+++ b/micronaut-langchain4j-store-pgvector/src/test/java/io/micronaut/langchain4j/pgvector/PgVectorEmbeddingStoreFactoryTest.java
@@ -84,10 +84,12 @@ class PgVectorEmbeddingStoreFactoryTest {
 
         @Override
         public void setLogWriter(PrintWriter out) {
+            // No-op: this test stub does not track mutable log-writer state.
         }
 
         @Override
         public void setLoginTimeout(int seconds) {
+            // No-op: this test stub does not enforce login timeouts.
         }
 
         @Override

--- a/micronaut-langchain4j-store-pgvector/src/test/java/io/micronaut/langchain4j/pgvector/PgVectorEmbeddingStoreFactoryTest.java
+++ b/micronaut-langchain4j-store-pgvector/src/test/java/io/micronaut/langchain4j/pgvector/PgVectorEmbeddingStoreFactoryTest.java
@@ -1,0 +1,147 @@
+package io.micronaut.langchain4j.pgvector;
+
+import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
+import io.micronaut.jdbc.DataSourceResolver;
+import java.io.PrintWriter;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class PgVectorEmbeddingStoreFactoryTest {
+
+    @Test
+    void unwrapsDataSourceBeforeConstructingStore() {
+        DataSource targetDataSource = new StubDataSource(false);
+        DataSource contextualDataSource = new StubDataSource(true);
+        DataSourceResolver dataSourceResolver = new DataSourceResolver() {
+            @Override
+            public DataSource resolve(DataSource dataSource) {
+                return targetDataSource;
+            }
+        };
+        PgVectorEmbeddingStoreFactory factory = new PgVectorEmbeddingStoreFactory(dataSourceResolver);
+        PgVectorEmbeddingStoreConfig configuration = new PgVectorEmbeddingStoreConfig(contextualDataSource, null);
+        configuration.setTable("test");
+        configuration.setDimension(384);
+        configuration.setCreateTable(false);
+        configuration.setDropTableFirst(false);
+
+        PgVectorEmbeddingStore embeddingStore = factory.pgVectorEmbeddingStore(configuration);
+
+        Assertions.assertNotNull(embeddingStore);
+    }
+
+    private static final class StubDataSource implements DataSource {
+        private final boolean failOnConnection;
+
+        private StubDataSource(boolean failOnConnection) {
+            this.failOnConnection = failOnConnection;
+        }
+
+        @Override
+        public Connection getConnection() throws SQLException {
+            if (failOnConnection) {
+                throw new SQLException("No current connection present");
+            }
+            return (Connection) Proxy.newProxyInstance(
+                    Connection.class.getClassLoader(),
+                    new Class<?>[] {Connection.class},
+                    (proxy, method, args) -> switch (method.getName()) {
+                        case "createStatement" -> Proxy.newProxyInstance(
+                                Statement.class.getClassLoader(),
+                                new Class<?>[] {Statement.class},
+                                (statementProxy, statementMethod, statementArgs) -> switch (statementMethod.getName()) {
+                                    case "execute", "executeUpdate", "close" -> null;
+                                    case "getConnection" -> proxy;
+                                    case "unwrap" -> statementArgs[0] == Statement.class ? statementProxy : null;
+                                    case "isWrapperFor" -> statementArgs[0] == Statement.class;
+                                    default -> defaultValue(statementMethod.getReturnType());
+                                }
+                        );
+                        case "close" -> null;
+                        case "unwrap" -> args[0] == Connection.class ? proxy : null;
+                        case "isWrapperFor" -> args[0] == Connection.class;
+                        default -> defaultValue(method.getReturnType());
+                    }
+            );
+        }
+
+        @Override
+        public Connection getConnection(String username, String password) throws SQLException {
+            return getConnection();
+        }
+
+        @Override
+        public PrintWriter getLogWriter() {
+            return null;
+        }
+
+        @Override
+        public void setLogWriter(PrintWriter out) {
+        }
+
+        @Override
+        public void setLoginTimeout(int seconds) {
+        }
+
+        @Override
+        public int getLoginTimeout() {
+            return 0;
+        }
+
+        @Override
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            throw new SQLFeatureNotSupportedException();
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) throws SQLException {
+            if (iface.isInstance(this)) {
+                return iface.cast(this);
+            }
+            throw new SQLException("Unsupported unwrap target: " + iface.getName());
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) {
+            return iface.isInstance(this);
+        }
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == byte.class) {
+            return (byte) 0;
+        }
+        if (returnType == short.class) {
+            return (short) 0;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        if (returnType == long.class) {
+            return 0L;
+        }
+        if (returnType == float.class) {
+            return 0F;
+        }
+        if (returnType == double.class) {
+            return 0D;
+        }
+        if (returnType == char.class) {
+            return '\0';
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- resolve configured PGVector data sources through Micronauts `DataSourceResolver` before store construction
- add a regression test that fails when a wrapped datasource is passed through unchanged

## Verification
- `./gradlew :micronaut-langchain4j-store-pgvector:test --tests 'io.micronaut.langchain4j.pgvector.PgVectorEmbeddingStoreFactoryTest'
- `./gradlew :micronaut-langchain4j-store-pgvector:test` *(fails locally because Testcontainers Ryuk cannot connect back to `host.multicode.test` in this environment)*

Resolves #268
