### PR TITLE
Qualify generated default chat model beans by name

### DIFF
--- a/micronaut-langchain4j-openai/src/test/java/io/micronaut/langchain4j/openai/OpenAiChatModelBuilderTest.java
+++ b/micronaut-langchain4j-openai/src/test/java/io/micronaut/langchain4j/openai/OpenAiChatModelBuilderTest.java
@@ -1,7 +1,14 @@
 package io.micronaut.langchain4j.openai;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
-import io.micronaut.context.BeanContext;import io.micronaut.context.annotation.Property;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
@@ -9,6 +16,9 @@ import org.junit.jupiter.api.Test;
 @MicronautTest(startApplication = false)
 @Property(name = "langchain4j.open-ai.api-key", value = "blah")
 @Property(name = "langchain4j.open-ai.organization-id", value = "blah")
+@Property(name = "langchain4j.open-ai.chat-models.default.model-name", value = "gpt-4.1")
+@Property(name = "langchain4j.open-ai.chat-models.pirate.model-name", value = "gpt-4o-mini")
+@Property(name = "langchain4j.open-ai.chat-models.poet.model-name", value = "gpt-4.1-mini")
 public class OpenAiChatModelBuilderTest {
 
     @Inject
@@ -18,6 +28,22 @@ public class OpenAiChatModelBuilderTest {
     void openAiChatModelBuilder() {
         beanContext.containsBean(OpenAiChatModel.class);
         beanContext.containsBean(OpenAiChatModel.OpenAiChatModelBuilder.class);
+    }
+
+    @Test
+    void namedChatModelsAreResolvableByQualifier() {
+        assertEquals(1, beanContext.getBeansOfType(OpenAiChatModel.OpenAiChatModelBuilder.class, Qualifiers.byName("default")).size());
+        assertTrue(beanContext.containsBean(OpenAiChatModel.OpenAiChatModelBuilder.class, Qualifiers.byName("default")));
+        assertTrue(beanContext.containsBean(OpenAiChatModel.OpenAiChatModelBuilder.class, Qualifiers.byName("pirate")));
+        assertTrue(beanContext.containsBean(OpenAiChatModel.OpenAiChatModelBuilder.class, Qualifiers.byName("poet")));
+        assertEquals(1, beanContext.getBeansOfType(ChatModel.class, Qualifiers.byName("default")).size());
+        assertTrue(beanContext.containsBean(ChatModel.class, Qualifiers.byName("default")));
+        assertTrue(beanContext.containsBean(ChatModel.class, Qualifiers.byName("pirate")));
+        assertTrue(beanContext.containsBean(ChatModel.class, Qualifiers.byName("poet")));
+        assertNotNull(beanContext.getBean(ChatModel.class, Qualifiers.byName("default")));
+        assertNotNull(beanContext.getBean(ChatModel.class, Qualifiers.byName("pirate")));
+        assertNotNull(beanContext.getBean(ChatModel.class, Qualifiers.byName("poet")));
+        assertNotNull(beanContext.getBean(ChatModel.class));
     }
 
 }

--- a/micronaut-langchain4j-processor/src/main/java/io/micronaut/langchain4j/processor/Langchain4jConfigVisitor.java
+++ b/micronaut-langchain4j-processor/src/main/java/io/micronaut/langchain4j/processor/Langchain4jConfigVisitor.java
@@ -75,6 +75,7 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
         "StreamingChatLanguageModel", "StreamingChatModel"
     );
     private static final String CTOR_NAME = "<init>";
+    private static final String GET_BUILDER_METHOD = "getBuilder";
     private final Set<String> writtenSourceClasses = new HashSet<>();
 
     @Override
@@ -265,7 +266,7 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
         MethodDef.MethodBodyBuilder methodBody = (aThis, methodParameters) -> {
             VariableDef.MethodParameter methodParameter = methodParameters.get(0);
             return methodParameter.invoke(
-                MethodDef.builder("getBuilder").returns(TypeDef.of(spec.builderType())).build()
+                MethodDef.builder(GET_BUILDER_METHOD).returns(TypeDef.of(spec.builderType())).build()
             ).returning();
         };
         return ClassDef.builder(spec.factoryName())
@@ -305,7 +306,7 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
                         .addMember("value", new VariableDef.StaticField(ClassTypeDef.of(builderTypeDef.getCanonicalName()), "class", TypeDef.of(Class.class)))
                         .build())
                     .addParameter("builder", builderTypeDef)
-                    .returns(spec.exposed() != null ? ClassTypeDef.of(spec.exposed()) : ClassTypeDef.of(spec.languageModel()))
+                    .returns(resolveFactoryReturnType(spec))
                     .build((aThis, parameters) -> {
                         VariableDef.MethodParameter builder = parameters.get(0);
                         return builder.invoke(MethodDef.builder("build").returns(ClassTypeDef.of(spec.languageModel())).build())
@@ -348,7 +349,7 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
         FieldDef builderField = FieldDef.builder("builder")
             .addAnnotation(AnnotationDef.builder(ConfigurationBuilder.class)
                 .addMember("prefixes", "")
-                .addMember("excludes", Arrays.asList(allExcludes))
+                .addMember("excludes", (Object) Arrays.asList(allExcludes))
                 .build())
             .initializer(
                 ClassTypeDef.of(model.getName()).invokeStatic(
@@ -366,7 +367,7 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
             .addField(
                 builderField
             )
-            .addMethod(MethodDef.builder("getBuilder")
+            .addMethod(MethodDef.builder(GET_BUILDER_METHOD)
                 .returns(TypeDef.of(builderType))
                 .build((aThis, parameters) ->
                     aThis.field("builder", TypeDef.of(builderType)).returning()
@@ -456,6 +457,14 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
         };
     }
 
+    private static TypeDef resolveFactoryReturnType(FactoryBuildSpec spec) {
+        ClassElement exposed = spec.exposed();
+        if (exposed != null) {
+            return ClassTypeDef.of(exposed);
+        }
+        return ClassTypeDef.of(spec.languageModel());
+    }
+
     static AnnotationDef defaultNamedAnnotation() {
         return AnnotationDef.builder(Named.class)
             .addMember("value", "default")
@@ -494,7 +503,7 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
         FieldDef builderField = FieldDef.builder("builder")
             .addAnnotation(AnnotationDef.builder(ConfigurationBuilder.class)
                 .addMember("prefixes", "")
-                .addMember("excludes", Arrays.asList(allExcludes))
+                .addMember("excludes", (Object) Arrays.asList(allExcludes))
                 .build())
             .initializer(ClassTypeDef.of(model.getName()).invokeStatic(builderMethod))
             .ofType(TypeDef.of(builderType))
@@ -510,7 +519,7 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
             .addField(
                 builderField
             )
-            .addMethod(MethodDef.builder("getBuilder")
+            .addMethod(MethodDef.builder(GET_BUILDER_METHOD)
                 .returns(TypeDef.of(builderType))
                 .build((aThis, methodParameters) -> aThis.field(builderField).returning()));
 

--- a/micronaut-langchain4j-processor/src/main/java/io/micronaut/langchain4j/processor/Langchain4jConfigVisitor.java
+++ b/micronaut-langchain4j-processor/src/main/java/io/micronaut/langchain4j/processor/Langchain4jConfigVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ import io.micronaut.sourcegen.model.RecordDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import io.micronaut.sourcegen.model.VariableDef;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
@@ -154,6 +155,7 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
                         ClassDef factoryDef = buildFactory(
                             namedConfigDef,
                             defaultConfigDef,
+                            namedPrefix,
                             modelConfig.builderType,
                             factoryName,
                             modelConfig.languageModel(),
@@ -260,6 +262,7 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
     private ClassDef buildFactory(
         ClassDef namedConfigDef,
         ClassDef defaultConfigDef,
+        String namedPrefix,
         ClassElement builderType,
         String factoryName,
         ClassElement languageModel,
@@ -290,9 +293,15 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
                 MethodDef.builder("primaryBuilder")
                     .addModifiers(Modifier.PROTECTED)
                     .addAnnotation(Bean.class)
+                    .addAnnotation(AnnotationDef.builder(Named.class)
+                        .addMember("value", "default")
+                        .build())
                     .addAnnotation(Primary.class)
                     .addAnnotation(AnnotationDef.builder(Requires.class)
                         .addMember("beans", new VariableDef.StaticField(ClassTypeDef.of(defaultConfigDef.asTypeDef().getCanonicalName()), "class", TypeDef.of(Class.class)))
+                        .build())
+                    .addAnnotation(AnnotationDef.builder(Requires.class)
+                        .addMember("missingProperty", namedPrefix + ".default")
                         .build())
                     .addParameter("config", defaultConfigDef.asTypeDef())
                     .returns(TypeDef.of(builderType))
@@ -365,6 +374,7 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(AnnotationDef.builder(EachProperty.class)
                 .addMember("value", prefix)
+                .addMember("primary", "default")
                 .build()
             )
             .addAnnotation(Context.class)

--- a/micronaut-langchain4j-processor/src/main/java/io/micronaut/langchain4j/processor/Langchain4jConfigVisitor.java
+++ b/micronaut-langchain4j-processor/src/main/java/io/micronaut/langchain4j/processor/Langchain4jConfigVisitor.java
@@ -152,7 +152,7 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
 
                     String factoryName = packageName + "." + factorySimpleName;
                     if (context.getClassElement(factoryName).isEmpty()) {
-                        ClassDef factoryDef = buildFactory(
+                        ClassDef factoryDef = buildFactory(new FactoryBuildSpec(
                             namedConfigDef,
                             defaultConfigDef,
                             namedPrefix,
@@ -161,7 +161,7 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
                             modelConfig.languageModel(),
                             modelConfig.languageModelKind(),
                             modelConfig.exposed()
-                        );
+                        ));
                         writeJavaSource(generator, context, element, packageName, factorySimpleName, factoryDef, modelConfig.modelKind);
                     }
 
@@ -259,24 +259,16 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
         return new ModelConfig(languageModel, languageModelKind, defaultModelName, exposedKind, configRequired);
     }
 
-    private ClassDef buildFactory(
-        ClassDef namedConfigDef,
-        ClassDef defaultConfigDef,
-        String namedPrefix,
-        ClassElement builderType,
-        String factoryName,
-        ClassElement languageModel,
-        ClassElement languageModelKind,
-        @Nullable ClassElement exposed) {
-        ClassTypeDef namedConfigDefTypeDef = namedConfigDef.asTypeDef();
-        ClassTypeDef builderTypeDef = ClassTypeDef.of(builderType);
+    private ClassDef buildFactory(FactoryBuildSpec spec) {
+        ClassTypeDef namedConfigDefTypeDef = spec.namedConfigDef().asTypeDef();
+        ClassTypeDef builderTypeDef = ClassTypeDef.of(spec.builderType());
         MethodDef.MethodBodyBuilder methodBody = (aThis, methodParameters) -> {
             VariableDef.MethodParameter methodParameter = methodParameters.get(0);
             return methodParameter.invoke(
-                MethodDef.builder("getBuilder").returns(TypeDef.of(builderType)).build()
+                MethodDef.builder("getBuilder").returns(TypeDef.of(spec.builderType())).build()
             ).returning();
         };
-        return ClassDef.builder(factoryName)
+        return ClassDef.builder(spec.factoryName())
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(Factory.class)
             .addMethod(
@@ -286,41 +278,37 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
                         .addMember("value", new VariableDef.StaticField(ClassTypeDef.of(namedConfigDefTypeDef.getCanonicalName()), "class", TypeDef.of(Class.class)))
                         .build())
                     .addParameter("config", namedConfigDefTypeDef)
-                    .returns(TypeDef.of(builderType))
+                    .returns(TypeDef.of(spec.builderType()))
                     .build(methodBody)
             )
             .addMethod(
                 MethodDef.builder("primaryBuilder")
                     .addModifiers(Modifier.PROTECTED)
                     .addAnnotation(Bean.class)
-                    .addAnnotation(AnnotationDef.builder(Named.class)
-                        .addMember("value", "default")
-                        .build())
+                    .addAnnotation(defaultNamedAnnotation())
                     .addAnnotation(Primary.class)
                     .addAnnotation(AnnotationDef.builder(Requires.class)
-                        .addMember("beans", new VariableDef.StaticField(ClassTypeDef.of(defaultConfigDef.asTypeDef().getCanonicalName()), "class", TypeDef.of(Class.class)))
+                        .addMember("beans", new VariableDef.StaticField(ClassTypeDef.of(spec.defaultConfigDef().asTypeDef().getCanonicalName()), "class", TypeDef.of(Class.class)))
                         .build())
-                    .addAnnotation(AnnotationDef.builder(Requires.class)
-                        .addMember("missingProperty", namedPrefix + ".default")
-                        .build())
-                    .addParameter("config", defaultConfigDef.asTypeDef())
-                    .returns(TypeDef.of(builderType))
+                    .addAnnotation(missingNamedDefaultPropertyRequirement(spec.namedPrefix()))
+                    .addParameter("config", spec.defaultConfigDef().asTypeDef())
+                    .returns(TypeDef.of(spec.builderType()))
                     .build(methodBody)
             ).addMethod(
                 MethodDef.builder("model")
                     .addModifiers(Modifier.PROTECTED)
                     .addAnnotation(Context.class)
                     .addAnnotation(AnnotationDef.builder(Bean.class)
-                        .addMember("typed", new VariableDef.StaticField(ClassTypeDef.of(languageModelKind.getRawClassElement().getName()), "class", TypeDef.of(Class.class)))
+                        .addMember("typed", new VariableDef.StaticField(ClassTypeDef.of(spec.languageModelKind().getRawClassElement().getName()), "class", TypeDef.of(Class.class)))
                         .build())
                     .addAnnotation(AnnotationDef.builder(EachBean.class)
                         .addMember("value", new VariableDef.StaticField(ClassTypeDef.of(builderTypeDef.getCanonicalName()), "class", TypeDef.of(Class.class)))
                         .build())
                     .addParameter("builder", builderTypeDef)
-                    .returns(exposed != null ? ClassTypeDef.of(exposed) : ClassTypeDef.of(languageModel))
+                    .returns(spec.exposed() != null ? ClassTypeDef.of(spec.exposed()) : ClassTypeDef.of(spec.languageModel()))
                     .build((aThis, parameters) -> {
                         VariableDef.MethodParameter builder = parameters.get(0);
-                        return builder.invoke(MethodDef.builder("build").returns(ClassTypeDef.of(languageModel)).build())
+                        return builder.invoke(MethodDef.builder("build").returns(ClassTypeDef.of(spec.languageModel())).build())
                             .returning();
                     })
             ).build();
@@ -372,11 +360,7 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
             .build();
         ClassDef.ClassDefBuilder classDefBuilder = ClassDef.builder(configurationClassName)
             .addModifiers(Modifier.PUBLIC)
-            .addAnnotation(AnnotationDef.builder(EachProperty.class)
-                .addMember("value", prefix)
-                .addMember("primary", "default")
-                .build()
-            )
+            .addAnnotation(eachPropertyWithPrimaryDefaultAnnotation(prefix))
             .addAnnotation(Context.class)
             .addField(prefixField)
             .addField(
@@ -470,6 +454,25 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
                     modelNameParameter
                 );
         };
+    }
+
+    static AnnotationDef defaultNamedAnnotation() {
+        return AnnotationDef.builder(Named.class)
+            .addMember("value", "default")
+            .build();
+    }
+
+    static AnnotationDef missingNamedDefaultPropertyRequirement(String namedPrefix) {
+        return AnnotationDef.builder(Requires.class)
+            .addMember("missingProperty", namedPrefix + ".default")
+            .build();
+    }
+
+    static AnnotationDef eachPropertyWithPrimaryDefaultAnnotation(String prefix) {
+        return AnnotationDef.builder(EachProperty.class)
+            .addMember("value", prefix)
+            .addMember("primary", "default")
+            .build();
     }
 
     private static ClassDef buildDefaultConfigurationDef(
@@ -637,6 +640,17 @@ public class Langchain4jConfigVisitor implements TypeElementVisitor<Lang4jConfig
         public String getCommonPrefix() {
             return CONFIG_PREFIX + NameUtils.hyphenate(modelName, true);
         }
+    }
+
+    private record FactoryBuildSpec(
+        ClassDef namedConfigDef,
+        ClassDef defaultConfigDef,
+        String namedPrefix,
+        ClassElement builderType,
+        String factoryName,
+        ClassElement languageModel,
+        ClassElement languageModelKind,
+        @Nullable ClassElement exposed) {
     }
 
     @SuppressWarnings("ClassExplicitlyAnnotation")

--- a/micronaut-langchain4j-processor/src/test/java/io/micronaut/langchain4j/processor/Langchain4jConfigVisitorBehaviorTest.java
+++ b/micronaut-langchain4j-processor/src/test/java/io/micronaut/langchain4j/processor/Langchain4jConfigVisitorBehaviorTest.java
@@ -1,0 +1,94 @@
+package io.micronaut.langchain4j.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import java.lang.reflect.Method;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class Langchain4jConfigVisitorBehaviorTest extends AbstractTypeElementSpec {
+
+    @Test
+    void namedDefaultConfigurationBecomesThePrimaryQualifiedBean() throws ClassNotFoundException {
+        try (ApplicationContext context = buildContext("test.TestModule", """
+            package test;
+
+            import static io.micronaut.langchain4j.annotation.Lang4jConfig.*;
+
+            import io.micronaut.langchain4j.annotation.Lang4jConfig;
+
+            @Lang4jConfig(
+                models = @Model(
+                    kind = StubKind.class,
+                    impl = StubModel.class,
+                    defaultModelName = "fallback-model"
+                ),
+                properties = @Property(name = "modelName", required = true)
+            )
+            final class TestModule {
+            }
+
+            interface StubKind {
+                String getModelName();
+            }
+
+            final class StubModel implements StubKind {
+                private final String modelName;
+
+                StubModel(String modelName) {
+                    this.modelName = modelName;
+                }
+
+                @Override
+                public String getModelName() {
+                    return modelName;
+                }
+
+                static Builder builder() {
+                    return new Builder();
+                }
+
+                static final class Builder {
+                    private String modelName;
+
+                    Builder modelName(String modelName) {
+                        this.modelName = modelName;
+                        return this;
+                    }
+
+                    StubModel build() {
+                        return new StubModel(modelName);
+                    }
+                }
+            }
+            """, false, Map.of(
+            "langchain4j.stub-model.stub-kind.model-name", "singular-default",
+            "langchain4j.stub-model.stub-kinds.default.model-name", "named-default",
+            "langchain4j.stub-model.stub-kinds.pirate.model-name", "pirate-model"
+        ))) {
+            Class<?> builderType = context.getClassLoader().loadClass("test.StubModel$Builder");
+            Class<?> modelType = context.getClassLoader().loadClass("test.StubKind");
+
+            assertEquals(2, context.getBeansOfType(builderType).size());
+            assertEquals(1, context.getBeansOfType(builderType, Qualifiers.byName("default")).size());
+            assertEquals(1, context.getBeansOfType(builderType, Qualifiers.byName("pirate")).size());
+            assertEquals(2, context.getBeansOfType(modelType).size());
+            assertEquals(1, context.getBeansOfType(modelType, Qualifiers.byName("default")).size());
+            assertEquals(1, context.getBeansOfType(modelType, Qualifiers.byName("pirate")).size());
+            assertEquals("default", modelName(context.getBean(modelType)));
+            assertEquals("default", modelName(context.getBean(modelType, Qualifiers.byName("default"))));
+            assertEquals("pirate", modelName(context.getBean(modelType, Qualifiers.byName("pirate"))));
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static Object modelName(Object bean) throws ReflectiveOperationException {
+        Method method = bean.getClass().getDeclaredMethod("getModelName");
+        method.setAccessible(true);
+        return method.invoke(bean);
+    }
+}

--- a/micronaut-langchain4j-processor/src/test/java/io/micronaut/langchain4j/processor/Langchain4jConfigVisitorTest.java
+++ b/micronaut-langchain4j-processor/src/test/java/io/micronaut/langchain4j/processor/Langchain4jConfigVisitorTest.java
@@ -63,7 +63,7 @@ class Langchain4jConfigVisitorTest {
             try {
                 Method method = target.getClass().getMethod(methodName);
                 return method.invoke(target);
-            } catch (NoSuchMethodException ignored) {
+            } catch (NoSuchMethodException _) {
                 // Try the next candidate.
             } catch (IllegalAccessException | InvocationTargetException e) {
                 throw new IllegalStateException("Unable to invoke " + methodName + " on " + target.getClass().getName(), e);

--- a/micronaut-langchain4j-processor/src/test/java/io/micronaut/langchain4j/processor/Langchain4jConfigVisitorTest.java
+++ b/micronaut-langchain4j-processor/src/test/java/io/micronaut/langchain4j/processor/Langchain4jConfigVisitorTest.java
@@ -1,0 +1,74 @@
+package io.micronaut.langchain4j.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.sourcegen.model.AnnotationDef;
+import jakarta.inject.Named;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class Langchain4jConfigVisitorTest {
+
+    @Test
+    void createsDefaultNamedAnnotation() {
+        AnnotationDef annotation = Langchain4jConfigVisitor.defaultNamedAnnotation();
+
+        assertEquals(Named.class.getName(), annotationTypeName(annotation));
+        assertMemberContains(annotation, "value", "default");
+    }
+
+    @Test
+    void createsNamedDefaultPropertyRequirement() {
+        AnnotationDef annotation = Langchain4jConfigVisitor.missingNamedDefaultPropertyRequirement("langchain4j.open-ai.chat-models");
+
+        assertEquals(Requires.class.getName(), annotationTypeName(annotation));
+        assertMemberContains(annotation, "missingProperty", "langchain4j.open-ai.chat-models.default");
+    }
+
+    @Test
+    void createsPrimaryDefaultEachPropertyAnnotation() {
+        AnnotationDef annotation = Langchain4jConfigVisitor.eachPropertyWithPrimaryDefaultAnnotation("langchain4j.open-ai.chat-models");
+
+        assertEquals(EachProperty.class.getName(), annotationTypeName(annotation));
+        assertMemberContains(annotation, "value", "langchain4j.open-ai.chat-models");
+        assertMemberContains(annotation, "primary", "default");
+    }
+
+    private static void assertMemberContains(AnnotationDef annotation, String memberName, String expectedValue) {
+        Object memberValue = annotationMembers(annotation).get(memberName);
+
+        assertNotNull(memberValue, () -> "Missing annotation member: " + memberName);
+        assertTrue(memberValue.toString().contains(expectedValue), () -> "Expected " + memberName + " to contain " + expectedValue + " but was " + memberValue);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> annotationMembers(AnnotationDef annotation) {
+        return (Map<String, Object>) invokeZeroArg(annotation, "getValues", "getMembers");
+    }
+
+    private static String annotationTypeName(AnnotationDef annotation) {
+        Object type = invokeZeroArg(annotation, "getType", "getAnnotationType");
+        Object name = invokeZeroArg(type, "getName", "getCanonicalName");
+        return name.toString();
+    }
+
+    private static Object invokeZeroArg(Object target, String... methodNames) {
+        for (String methodName : methodNames) {
+            try {
+                Method method = target.getClass().getMethod(methodName);
+                return method.invoke(target);
+            } catch (NoSuchMethodException ignored) {
+                // Try the next candidate.
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new IllegalStateException("Unable to invoke " + methodName + " on " + target.getClass().getName(), e);
+            }
+        }
+        throw new IllegalStateException("No compatible zero-arg method found on " + target.getClass().getName());
+    }
+}


### PR DESCRIPTION
## Summary
- qualify generated default chat model builders with the `default` name so default `ChatModel` beans can be resolved by qualifier
- preserve the existing named configuration flow while avoiding collisions when `chat-models.default` is configured
- add OpenAI regression coverage for `default`, `pirate`, and `poet` qualifier resolution

## Verification
- `./gradlew :micronaut-langchain4j-openai:test --tests io.micronaut.langchain4j.openai.OpenAiChatModelBuilderTest`

Resolves #180
