### PR TITLE
Require config for Vertex AI image and embedding models

### DIFF
--- a/micronaut-langchain4j-vertexai/src/main/java/io/micronaut/langchain4j/vertexai/VertexAiModule.java
+++ b/micronaut-langchain4j-vertexai/src/main/java/io/micronaut/langchain4j/vertexai/VertexAiModule.java
@@ -33,11 +33,13 @@ import io.micronaut.langchain4j.annotation.Lang4jConfig;
         ,
         @Model(
             kind = ImageModel.class,
-            impl = VertexAiImageModel.class
+            impl = VertexAiImageModel.class,
+            configRequired = true
         ),
         @Model(
             kind = EmbeddingModel.class,
-            impl = VertexAiEmbeddingModel.class
+            impl = VertexAiEmbeddingModel.class,
+            configRequired = true
         )
     },
     properties = {


### PR DESCRIPTION
running vertex ai tests without providing the environment variables `LANGCHAIN4J_VERTEX_AI_ENDPOINT`, `LANGCHAIN4J_VERTEX_AI_PROJECT`, `LANGCHAIN4J_VERTEX_AI_LOCATION` fails with:

```
./gradlew :micronaut-langchain4j-vertexai:test
Type-safe project accessors is an incubating feature.
Project accessors enabled, but root project name not explicitly set for 'buildSrc'. Checking out the project in different folders will impact the generated code and implicitly the buildscript classpath, breaking caching.

4 tests completed, 4 failed

> Task :micronaut-langchain4j-vertexai:test FAILED

Predictive Test Selection: 1 of 2 test classes selected with profile 'Standard' (saving 0.149s serial time)
Test Run :micronaut-langchain4j-vertexai:test > Partition 1 in session 2 on localhost-executor-1 > ChatModels Test Compatibility Kit for the Vertex AI PaLM 2 implementation > JUnit Jupiter > AiServiceMemoryIdTest initializationError FAILED

  io.micronaut.context.exceptions.BeanInstantiationException: Bean definition [io.micronaut.langchain4j.vertexai.DefaultVertexAiImageModelConfiguration] could not be loaded: Failed to inject value for parameter [endpoint] of class: io.micronaut.langchain4j.vertexai.CommonVertexAiChatModelConfiguration

  Message: Failed to inject value for parameter [endpoint] of class: io.micronaut.langchain4j.vertexai.CommonVertexAiChatModelConfiguration

  Message: Error resolving property value [langchain4j.vertex-ai.endpoint]. Property doesn't exist
  Path Taken:
  new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration(CommonVertexAiChatModelConfiguration config)
  ---> new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration([CommonVertexAiChatModelConfiguration config])
        ---> new @i.m.c.a.Context("langchain4j.vertex-ai") i.m.l.v.CommonVertexAiChatModelConfiguration(boolean enabled, [String endpoint], String modelName, String project, String location, String publisher, Integer maxRetries)
  Path Taken:
  new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration(CommonVertexAiChatModelConfiguration config)
  ---> new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration([CommonVertexAiChatModelConfiguration config])
        ---> new @i.m.c.a.Context("langchain4j.vertex-ai") i.m.l.v.CommonVertexAiChatModelConfiguration(boolean enabled, [String endpoint], String modelName, String project, String location, String publisher, Integer maxRetries)
      at app//io.micronaut.context.DefaultBeanContext.initializeEagerBeans(DefaultBeanContext.java:1901)
      at app//io.micronaut.context.DefaultBeanContext.initializeContext(DefaultBeanContext.java:1823)
      at app//io.micronaut.context.DefaultBeanContext.configureAndStartContext(DefaultBeanContext.java:3011)
      at app//io.micronaut.context.DefaultBeanContext.start(DefaultBeanContext.java:330)
      at app//io.micronaut.context.DefaultApplicationContext.start(DefaultApplicationContext.java:293)
      at app//io.micronaut.test.extensions.AbstractMicronautExtension.startApplicationContext(AbstractMicronautExtension.java:501)
      at app//io.micronaut.test.extensions.AbstractMicronautExtension.beforeClass(AbstractMicronautExtension.java:373)
      at app//io.micronaut.test.extensions.junit5.MicronautJunit5Extension.beforeAll(MicronautJunit5Extension.java:86)
      at java.base@25.0.3/java.util.ArrayList.forEach(ArrayList.java:1604)
  Caused by: io.micronaut.context.exceptions.DependencyInjectionException: Failed to inject value for parameter [endpoint] of class: io.micronaut.langchain4j.vertexai.CommonVertexAiChatModelConfiguration

  Message: Failed to inject value for parameter [endpoint] of class: io.micronaut.langchain4j.vertexai.CommonVertexAiChatModelConfiguration

  Message: Error resolving property value [langchain4j.vertex-ai.endpoint]. Property doesn't exist
  Path Taken:
  new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration(CommonVertexAiChatModelConfiguration config)
  ---> new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration([CommonVertexAiChatModelConfiguration config])
        ---> new @i.m.c.a.Context("langchain4j.vertex-ai") i.m.l.v.CommonVertexAiChatModelConfiguration(boolean enabled, [String endpoint], String modelName, String project, String location, String publisher, Integer maxRetries)
  Path Taken:
  new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration(CommonVertexAiChatModelConfiguration config)
  ---> new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration([CommonVertexAiChatModelConfiguration config])
        ---> new @i.m.c.a.Context("langchain4j.vertex-ai") i.m.l.v.CommonVertexAiChatModelConfiguration(boolean enabled, [String endpoint], String modelName, String project, String location, String publisher, Integer maxRetries)
      at app//io.micronaut.context.exceptions.DependencyInjectionException.missingProperty(DependencyInjectionException.java:290)
      at app//io.micronaut.context.AbstractBeanResolutionContext.lambda$resolvePropertyValue$1(AbstractBeanResolutionContext.java:221)
      at java.base@25.0.3/java.util.Optional.orElseThrow(Optional.java:403)
      at app//io.micronaut.context.AbstractBeanResolutionContext.resolvePropertyValue(AbstractBeanResolutionContext.java:221)
      at app//io.micronaut.context.AbstractInitializableBeanDefinition.getPropertyValueForConstructorArgument(AbstractInitializableBeanDefinition.java:1490)
      at app//io.micronaut.langchain4j.vertexai.$CommonVertexAiChatModelConfiguration$Definition.instantiate(Unknown Source)
      at app//io.micronaut.context.DefaultBeanContext.resolveByBeanFactory(DefaultBeanContext.java:2092)
      at app//io.micronaut.context.DefaultBeanContext.createRegistration(DefaultBeanContext.java:2803)
      at app//io.micronaut.context.SingletonScope.getOrCreate(SingletonScope.java:78)
      at app//io.micronaut.context.DefaultBeanContext.resolveBeanRegistration(DefaultBeanContext.java:2657)
      at app//io.micronaut.context.DefaultBeanContext.resolveBeanRegistration(DefaultBeanContext.java:2410)
      at app//io.micronaut.context.DefaultBeanContext.getBean(DefaultBeanContext.java:1642)
      at app//io.micronaut.context.AbstractBeanResolutionContext.getBean(AbstractBeanResolutionContext.java:236)
      at app//io.micronaut.context.AbstractInitializableBeanDefinition.resolveBean(AbstractInitializableBeanDefinition.java:2209)
      at app//io.micronaut.context.AbstractInitializableBeanDefinition.getBeanForConstructorArgument(AbstractInitializableBeanDefinition.java:1423)
      at app//io.micronaut.langchain4j.vertexai.$DefaultVertexAiImageModelConfiguration$Definition.instantiate(Unknown Source)
      at app//io.micronaut.context.DefaultBeanContext.resolveByBeanFactory(DefaultBeanContext.java:2092)
      at app//io.micronaut.context.DefaultBeanContext.createRegistration(DefaultBeanContext.java:2803)
      at app//io.micronaut.context.SingletonScope.getOrCreate(SingletonScope.java:78)
      at app//io.micronaut.context.DefaultBeanContext.intializeEagerBean(DefaultBeanContext.java:2697)
      at app//io.micronaut.context.DefaultBeanContext.initializeEagerBean(DefaultBeanContext.java:2336)
      at app//io.micronaut.context.DefaultBeanContext.initializeEagerBeans(DefaultBeanContext.java:1895)
      ... 8 more

  16:29:45.991 [main] INFO  i.m.context.env.DefaultEnvironment - Established active environments: [test]

Test Run :micronaut-langchain4j-vertexai:test > Partition 1 in session 2 on localhost-executor-1 > ChatModels Test Compatibility Kit for the Vertex AI PaLM 2 implementation > JUnit Jupiter > BeanOfTypeChatLanguageModelExistsTest initializationError FAILED

  io.micronaut.context.exceptions.BeanInstantiationException: Bean definition [io.micronaut.langchain4j.vertexai.DefaultVertexAiImageModelConfiguration] could not be loaded: Failed to inject value for parameter [endpoint] of class: io.micronaut.langchain4j.vertexai.CommonVertexAiChatModelConfiguration

  Message: Failed to inject value for parameter [endpoint] of class: io.micronaut.langchain4j.vertexai.CommonVertexAiChatModelConfiguration

  Message: Error resolving property value [langchain4j.vertex-ai.endpoint]. Property doesn't exist
  Path Taken:
  new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration(CommonVertexAiChatModelConfiguration config)
  ---> new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration([CommonVertexAiChatModelConfiguration config])
        ---> new @i.m.c.a.Context("langchain4j.vertex-ai") i.m.l.v.CommonVertexAiChatModelConfiguration(boolean enabled, [String endpoint], String modelName, String project, String location, String publisher, Integer maxRetries)
  Path Taken:
  new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration(CommonVertexAiChatModelConfiguration config)
  ---> new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration([CommonVertexAiChatModelConfiguration config])
        ---> new @i.m.c.a.Context("langchain4j.vertex-ai") i.m.l.v.CommonVertexAiChatModelConfiguration(boolean enabled, [String endpoint], String modelName, String project, String location, String publisher, Integer maxRetries)
      at app//io.micronaut.context.DefaultBeanContext.initializeEagerBeans(DefaultBeanContext.java:1901)
      at app//io.micronaut.context.DefaultBeanContext.initializeContext(DefaultBeanContext.java:1823)
      at app//io.micronaut.context.DefaultBeanContext.configureAndStartContext(DefaultBeanContext.java:3011)
      at app//io.micronaut.context.DefaultBeanContext.start(DefaultBeanContext.java:330)
      at app//io.micronaut.context.DefaultApplicationContext.start(DefaultApplicationContext.java:293)
      at app//io.micronaut.test.extensions.AbstractMicronautExtension.startApplicationContext(AbstractMicronautExtension.java:501)
      at app//io.micronaut.test.extensions.AbstractMicronautExtension.beforeClass(AbstractMicronautExtension.java:373)
      at app//io.micronaut.test.extensions.junit5.MicronautJunit5Extension.beforeAll(MicronautJunit5Extension.java:86)
      at java.base@25.0.3/java.util.ArrayList.forEach(ArrayList.java:1604)
  Caused by: io.micronaut.context.exceptions.DependencyInjectionException: Failed to inject value for parameter [endpoint] of class: io.micronaut.langchain4j.vertexai.CommonVertexAiChatModelConfiguration

  Message: Failed to inject value for parameter [endpoint] of class: io.micronaut.langchain4j.vertexai.CommonVertexAiChatModelConfiguration

  Message: Error resolving property value [langchain4j.vertex-ai.endpoint]. Property doesn't exist
  Path Taken:
  new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration(CommonVertexAiChatModelConfiguration config)
  ---> new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration([CommonVertexAiChatModelConfiguration config])
        ---> new @i.m.c.a.Context("langchain4j.vertex-ai") i.m.l.v.CommonVertexAiChatModelConfiguration(boolean enabled, [String endpoint], String modelName, String project, String location, String publisher, Integer maxRetries)
  Path Taken:
  new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration(CommonVertexAiChatModelConfiguration config)
  ---> new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration([CommonVertexAiChatModelConfiguration config])
        ---> new @i.m.c.a.Context("langchain4j.vertex-ai") i.m.l.v.CommonVertexAiChatModelConfiguration(boolean enabled, [String endpoint], String modelName, String project, String location, String publisher, Integer maxRetries)
      at app//io.micronaut.context.exceptions.DependencyInjectionException.missingProperty(DependencyInjectionException.java:290)
      at app//io.micronaut.context.AbstractBeanResolutionContext.lambda$resolvePropertyValue$1(AbstractBeanResolutionContext.java:221)
      at java.base@25.0.3/java.util.Optional.orElseThrow(Optional.java:403)
      at app//io.micronaut.context.AbstractBeanResolutionContext.resolvePropertyValue(AbstractBeanResolutionContext.java:221)
      at app//io.micronaut.context.AbstractInitializableBeanDefinition.getPropertyValueForConstructorArgument(AbstractInitializableBeanDefinition.java:1490)
      at app//io.micronaut.langchain4j.vertexai.$CommonVertexAiChatModelConfiguration$Definition.instantiate(Unknown Source)
      at app//io.micronaut.context.DefaultBeanContext.resolveByBeanFactory(DefaultBeanContext.java:2092)
      at app//io.micronaut.context.DefaultBeanContext.createRegistration(DefaultBeanContext.java:2803)
      at app//io.micronaut.context.SingletonScope.getOrCreate(SingletonScope.java:78)
      at app//io.micronaut.context.DefaultBeanContext.resolveBeanRegistration(DefaultBeanContext.java:2657)
      at app//io.micronaut.context.DefaultBeanContext.resolveBeanRegistration(DefaultBeanContext.java:2410)
      at app//io.micronaut.context.DefaultBeanContext.getBean(DefaultBeanContext.java:1642)
      at app//io.micronaut.context.AbstractBeanResolutionContext.getBean(AbstractBeanResolutionContext.java:236)
      at app//io.micronaut.context.AbstractInitializableBeanDefinition.resolveBean(AbstractInitializableBeanDefinition.java:2209)
      at app//io.micronaut.context.AbstractInitializableBeanDefinition.getBeanForConstructorArgument(AbstractInitializableBeanDefinition.java:1423)
      at app//io.micronaut.langchain4j.vertexai.$DefaultVertexAiImageModelConfiguration$Definition.instantiate(Unknown Source)
      at app//io.micronaut.context.DefaultBeanContext.resolveByBeanFactory(DefaultBeanContext.java:2092)
      at app//io.micronaut.context.DefaultBeanContext.createRegistration(DefaultBeanContext.java:2803)
      at app//io.micronaut.context.SingletonScope.getOrCreate(SingletonScope.java:78)
      at app//io.micronaut.context.DefaultBeanContext.intializeEagerBean(DefaultBeanContext.java:2697)
      at app//io.micronaut.context.DefaultBeanContext.initializeEagerBean(DefaultBeanContext.java:2336)
      at app//io.micronaut.context.DefaultBeanContext.initializeEagerBeans(DefaultBeanContext.java:1895)
      ... 8 more

  16:29:46.026 [main] INFO  i.m.context.env.DefaultEnvironment - Established active environments: [test]

Test Run :micronaut-langchain4j-vertexai:test > Partition 1 in session 2 on localhost-executor-1 > ChatModels Test Compatibility Kit for the Vertex AI PaLM 2 implementation > JUnit Jupiter > AiServiceFluxTest initializationError FAILED

  io.micronaut.context.exceptions.BeanInstantiationException: Bean definition [io.micronaut.langchain4j.vertexai.DefaultVertexAiImageModelConfiguration] could not be loaded: Failed to inject value for parameter [endpoint] of class: io.micronaut.langchain4j.vertexai.CommonVertexAiChatModelConfiguration

  Message: Failed to inject value for parameter [endpoint] of class: io.micronaut.langchain4j.vertexai.CommonVertexAiChatModelConfiguration

  Message: Error resolving property value [langchain4j.vertex-ai.endpoint]. Property doesn't exist
  Path Taken:
  new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration(CommonVertexAiChatModelConfiguration config)
  ---> new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration([CommonVertexAiChatModelConfiguration config])
        ---> new @i.m.c.a.Context("langchain4j.vertex-ai") i.m.l.v.CommonVertexAiChatModelConfiguration(boolean enabled, [String endpoint], String modelName, String project, String location, String publisher, Integer maxRetries)
  Path Taken:
  new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration(CommonVertexAiChatModelConfiguration config)
  ---> new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration([CommonVertexAiChatModelConfiguration config])
        ---> new @i.m.c.a.Context("langchain4j.vertex-ai") i.m.l.v.CommonVertexAiChatModelConfiguration(boolean enabled, [String endpoint], String modelName, String project, String location, String publisher, Integer maxRetries)
      at app//io.micronaut.context.DefaultBeanContext.initializeEagerBeans(DefaultBeanContext.java:1901)
      at app//io.micronaut.context.DefaultBeanContext.initializeContext(DefaultBeanContext.java:1823)
      at app//io.micronaut.context.DefaultBeanContext.configureAndStartContext(DefaultBeanContext.java:3011)
      at app//io.micronaut.context.DefaultBeanContext.start(DefaultBeanContext.java:330)
      at app//io.micronaut.context.DefaultApplicationContext.start(DefaultApplicationContext.java:293)
      at app//io.micronaut.test.extensions.AbstractMicronautExtension.startApplicationContext(AbstractMicronautExtension.java:501)
      at app//io.micronaut.test.extensions.AbstractMicronautExtension.beforeClass(AbstractMicronautExtension.java:373)
      at app//io.micronaut.test.extensions.junit5.MicronautJunit5Extension.beforeAll(MicronautJunit5Extension.java:86)
      at java.base@25.0.3/java.util.ArrayList.forEach(ArrayList.java:1604)
  Caused by: io.micronaut.context.exceptions.DependencyInjectionException: Failed to inject value for parameter [endpoint] of class: io.micronaut.langchain4j.vertexai.CommonVertexAiChatModelConfiguration

  Message: Failed to inject value for parameter [endpoint] of class: io.micronaut.langchain4j.vertexai.CommonVertexAiChatModelConfiguration

  Message: Error resolving property value [langchain4j.vertex-ai.endpoint]. Property doesn't exist
  Path Taken:
  new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration(CommonVertexAiChatModelConfiguration config)
  ---> new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration([CommonVertexAiChatModelConfiguration config])
        ---> new @i.m.c.a.Context("langchain4j.vertex-ai") i.m.l.v.CommonVertexAiChatModelConfiguration(boolean enabled, [String endpoint], String modelName, String project, String location, String publisher, Integer maxRetries)
  Path Taken:
  new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration(CommonVertexAiChatModelConfiguration config)
  ---> new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration([CommonVertexAiChatModelConfiguration config])
        ---> new @i.m.c.a.Context("langchain4j.vertex-ai") i.m.l.v.CommonVertexAiChatModelConfiguration(boolean enabled, [String endpoint], String modelName, String project, String location, String publisher, Integer maxRetries)
      at app//io.micronaut.context.exceptions.DependencyInjectionException.missingProperty(DependencyInjectionException.java:290)
      at app//io.micronaut.context.AbstractBeanResolutionContext.lambda$resolvePropertyValue$1(AbstractBeanResolutionContext.java:221)
      at java.base@25.0.3/java.util.Optional.orElseThrow(Optional.java:403)
      at app//io.micronaut.context.AbstractBeanResolutionContext.resolvePropertyValue(AbstractBeanResolutionContext.java:221)
      at app//io.micronaut.context.AbstractInitializableBeanDefinition.getPropertyValueForConstructorArgument(AbstractInitializableBeanDefinition.java:1490)
      at app//io.micronaut.langchain4j.vertexai.$CommonVertexAiChatModelConfiguration$Definition.instantiate(Unknown Source)
      at app//io.micronaut.context.DefaultBeanContext.resolveByBeanFactory(DefaultBeanContext.java:2092)
      at app//io.micronaut.context.DefaultBeanContext.createRegistration(DefaultBeanContext.java:2803)
      at app//io.micronaut.context.SingletonScope.getOrCreate(SingletonScope.java:78)
      at app//io.micronaut.context.DefaultBeanContext.resolveBeanRegistration(DefaultBeanContext.java:2657)
      at app//io.micronaut.context.DefaultBeanContext.resolveBeanRegistration(DefaultBeanContext.java:2410)
      at app//io.micronaut.context.DefaultBeanContext.getBean(DefaultBeanContext.java:1642)
      at app//io.micronaut.context.AbstractBeanResolutionContext.getBean(AbstractBeanResolutionContext.java:236)
      at app//io.micronaut.context.AbstractInitializableBeanDefinition.resolveBean(AbstractInitializableBeanDefinition.java:2209)
      at app//io.micronaut.context.AbstractInitializableBeanDefinition.getBeanForConstructorArgument(AbstractInitializableBeanDefinition.java:1423)
      at app//io.micronaut.langchain4j.vertexai.$DefaultVertexAiImageModelConfiguration$Definition.instantiate(Unknown Source)
      at app//io.micronaut.context.DefaultBeanContext.resolveByBeanFactory(DefaultBeanContext.java:2092)
      at app//io.micronaut.context.DefaultBeanContext.createRegistration(DefaultBeanContext.java:2803)
      at app//io.micronaut.context.SingletonScope.getOrCreate(SingletonScope.java:78)
      at app//io.micronaut.context.DefaultBeanContext.intializeEagerBean(DefaultBeanContext.java:2697)
      at app//io.micronaut.context.DefaultBeanContext.initializeEagerBean(DefaultBeanContext.java:2336)
      at app//io.micronaut.context.DefaultBeanContext.initializeEagerBeans(DefaultBeanContext.java:1895)
      ... 8 more

  16:29:46.040 [main] INFO  i.m.context.env.DefaultEnvironment - Established active environments: [test]

Test Run :micronaut-langchain4j-vertexai:test > Partition 1 in session 2 on localhost-executor-1 > ChatModels Test Compatibility Kit for the Vertex AI PaLM 2 implementation > JUnit Jupiter > ChatLanguageModelTest initializationError FAILED

  io.micronaut.context.exceptions.BeanInstantiationException: Bean definition [io.micronaut.langchain4j.vertexai.DefaultVertexAiImageModelConfiguration] could not be loaded: Failed to inject value for parameter [endpoint] of class: io.micronaut.langchain4j.vertexai.CommonVertexAiChatModelConfiguration

  Message: Failed to inject value for parameter [endpoint] of class: io.micronaut.langchain4j.vertexai.CommonVertexAiChatModelConfiguration

  Message: Error resolving property value [langchain4j.vertex-ai.endpoint]. Property doesn't exist
  Path Taken:
  new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration(CommonVertexAiChatModelConfiguration config)
  ---> new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration([CommonVertexAiChatModelConfiguration config])
        ---> new @i.m.c.a.Context("langchain4j.vertex-ai") i.m.l.v.CommonVertexAiChatModelConfiguration(boolean enabled, [String endpoint], String modelName, String project, String location, String publisher, Integer maxRetries)
  Path Taken:
  new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration(CommonVertexAiChatModelConfiguration config)
  ---> new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration([CommonVertexAiChatModelConfiguration config])
        ---> new @i.m.c.a.Context("langchain4j.vertex-ai") i.m.l.v.CommonVertexAiChatModelConfiguration(boolean enabled, [String endpoint], String modelName, String project, String location, String publisher, Integer maxRetries)
      at app//io.micronaut.context.DefaultBeanContext.initializeEagerBeans(DefaultBeanContext.java:1901)
      at app//io.micronaut.context.DefaultBeanContext.initializeContext(DefaultBeanContext.java:1823)
      at app//io.micronaut.context.DefaultBeanContext.configureAndStartContext(DefaultBeanContext.java:3011)
      at app//io.micronaut.context.DefaultBeanContext.start(DefaultBeanContext.java:330)
      at app//io.micronaut.context.DefaultApplicationContext.start(DefaultApplicationContext.java:293)
      at app//io.micronaut.test.extensions.AbstractMicronautExtension.startApplicationContext(AbstractMicronautExtension.java:501)
      at app//io.micronaut.test.extensions.AbstractMicronautExtension.beforeClass(AbstractMicronautExtension.java:373)
      at app//io.micronaut.test.extensions.junit5.MicronautJunit5Extension.beforeAll(MicronautJunit5Extension.java:86)
      at java.base@25.0.3/java.util.ArrayList.forEach(ArrayList.java:1604)
  Caused by: io.micronaut.context.exceptions.DependencyInjectionException: Failed to inject value for parameter [endpoint] of class: io.micronaut.langchain4j.vertexai.CommonVertexAiChatModelConfiguration

  Message: Failed to inject value for parameter [endpoint] of class: io.micronaut.langchain4j.vertexai.CommonVertexAiChatModelConfiguration

  Message: Error resolving property value [langchain4j.vertex-ai.endpoint]. Property doesn't exist
  Path Taken:
  new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration(CommonVertexAiChatModelConfiguration config)
  ---> new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration([CommonVertexAiChatModelConfiguration config])
        ---> new @i.m.c.a.Context("langchain4j.vertex-ai") i.m.l.v.CommonVertexAiChatModelConfiguration(boolean enabled, [String endpoint], String modelName, String project, String location, String publisher, Integer maxRetries)
  Path Taken:
  new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration(CommonVertexAiChatModelConfiguration config)
  ---> new @i.m.c.a.ConfigurationProperties("langchain4j.vertex-ai.image-model") i.m.l.v.DefaultVertexAiImageModelConfiguration([CommonVertexAiChatModelConfiguration config])
        ---> new @i.m.c.a.Context("langchain4j.vertex-ai") i.m.l.v.CommonVertexAiChatModelConfiguration(boolean enabled, [String endpoint], String modelName, String project, String location, String publisher, Integer maxRetries)
      at app//io.micronaut.context.exceptions.DependencyInjectionException.missingProperty(DependencyInjectionException.java:290)
      at app//io.micronaut.context.AbstractBeanResolutionContext.lambda$resolvePropertyValue$1(AbstractBeanResolutionContext.java:221)
      at java.base@25.0.3/java.util.Optional.orElseThrow(Optional.java:403)
      at app//io.micronaut.context.AbstractBeanResolutionContext.resolvePropertyValue(AbstractBeanResolutionContext.java:221)
      at app//io.micronaut.context.AbstractInitializableBeanDefinition.getPropertyValueForConstructorArgument(AbstractInitializableBeanDefinition.java:1490)
      at app//io.micronaut.langchain4j.vertexai.$CommonVertexAiChatModelConfiguration$Definition.instantiate(Unknown Source)
      at app//io.micronaut.context.DefaultBeanContext.resolveByBeanFactory(DefaultBeanContext.java:2092)
      at app//io.micronaut.context.DefaultBeanContext.createRegistration(DefaultBeanContext.java:2803)
      at app//io.micronaut.context.SingletonScope.getOrCreate(SingletonScope.java:78)
      at app//io.micronaut.context.DefaultBeanContext.resolveBeanRegistration(DefaultBeanContext.java:2657)
      at app//io.micronaut.context.DefaultBeanContext.resolveBeanRegistration(DefaultBeanContext.java:2410)
      at app//io.micronaut.context.DefaultBeanContext.getBean(DefaultBeanContext.java:1642)
      at app//io.micronaut.context.AbstractBeanResolutionContext.getBean(AbstractBeanResolutionContext.java:236)
      at app//io.micronaut.context.AbstractInitializableBeanDefinition.resolveBean(AbstractInitializableBeanDefinition.java:2209)
      at app//io.micronaut.context.AbstractInitializableBeanDefinition.getBeanForConstructorArgument(AbstractInitializableBeanDefinition.java:1423)
      at app//io.micronaut.langchain4j.vertexai.$DefaultVertexAiImageModelConfiguration$Definition.instantiate(Unknown Source)
      at app//io.micronaut.context.DefaultBeanContext.resolveByBeanFactory(DefaultBeanContext.java:2092)
      at app//io.micronaut.context.DefaultBeanContext.createRegistration(DefaultBeanContext.java:2803)
      at app//io.micronaut.context.SingletonScope.getOrCreate(SingletonScope.java:78)
      at app//io.micronaut.context.DefaultBeanContext.intializeEagerBean(DefaultBeanContext.java:2697)
      at app//io.micronaut.context.DefaultBeanContext.initializeEagerBean(DefaultBeanContext.java:2336)
      at app//io.micronaut.context.DefaultBeanContext.initializeEagerBeans(DefaultBeanContext.java:1895)
      ... 8 more

```

This PR changes the vertex ai module to make config required.