### PR TITLE
Fix Ollama tests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ jinjava = "2.8.3"
 tools-jackson-core = "3.1.3"
 
 # Managed versions appear in the BOM
-managed-langchain4j = "1.15.0"
+managed-langchain4j = "1.15.1"
 managed-langchain4j-community = "1.15.0-beta25"
 testcontainers-redis = "2.2.4"
 astra-db-client = "1.2.7"

--- a/test-suite-utils/src/main/java/io/micronaut/langchain4j/testutils/CassandraUtils.java
+++ b/test-suite-utils/src/main/java/io/micronaut/langchain4j/testutils/CassandraUtils.java
@@ -14,6 +14,8 @@ public final class CassandraUtils {
     static final String CASSANDRA_IMAGE = "cassandra:5.0";
     private static final String DATACENTER = "datacenter1";
     private static final String KEYSPACE = "langchain4j";
+    private static final String MAX_HEAP_SIZE = "512M";
+    private static final String MAX_DIRECT_MEMORY_SIZE = "256M";
     private static CassandraContainer container;
     private static InetSocketAddress contactPoint;
     private CassandraUtils() {
@@ -28,7 +30,10 @@ public final class CassandraUtils {
 
     public static Map<String, Object> getProperties() throws InterruptedException {
         if (container == null) {
-            container = new CassandraContainer(DockerImageName.parse(CASSANDRA_IMAGE));
+            container = new CassandraContainer(DockerImageName.parse(CASSANDRA_IMAGE))
+                .withEnv("MAX_HEAP_SIZE", MAX_HEAP_SIZE)
+                .withEnv("MAX_DIRECT_MEMORY_SIZE", MAX_DIRECT_MEMORY_SIZE)
+                .withEnv("HEAP_NEWSIZE", "");
             container.start();
             do {
                 LOG.info("Waiting for Cassandra container to be ready...");

--- a/test-suite-utils/src/main/java/io/micronaut/langchain4j/testutils/OllamaTestPropertyProvider.java
+++ b/test-suite-utils/src/main/java/io/micronaut/langchain4j/testutils/OllamaTestPropertyProvider.java
@@ -13,10 +13,8 @@ public interface OllamaTestPropertyProvider extends TestPropertyProvider {
     default Map<String, String> getProperties() {
         Map<String, String> result = new HashMap<>();
         try {
-            result.put("langchain4j.ollama.base-url", OllamaUtils.ollamaContainerBaseUrl());
-            result.put("langchain4j.ollama.embedding-model.model-name", OllamaUtils.ollamaEmbeddingModelName());
         } catch (Exception e) {
-            throw new ConfigurationException("Could not set Ollama base URL", e);
+            throw new ConfigurationException("Could not set Ollama test properties", e);
         }
         return result;
     }

--- a/test-suite-utils/src/main/java/io/micronaut/langchain4j/testutils/OllamaTestPropertyProvider.java
+++ b/test-suite-utils/src/main/java/io/micronaut/langchain4j/testutils/OllamaTestPropertyProvider.java
@@ -14,6 +14,7 @@ public interface OllamaTestPropertyProvider extends TestPropertyProvider {
         Map<String, String> result = new HashMap<>();
         try {
             result.put("langchain4j.ollama.base-url", OllamaUtils.ollamaContainerBaseUrl());
+            result.put("langchain4j.ollama.embedding-model.model-name", OllamaUtils.ollamaEmbeddingModelName());
         } catch (Exception e) {
             throw new ConfigurationException("Could not set Ollama base URL", e);
         }

--- a/test-suite-utils/src/main/java/io/micronaut/langchain4j/testutils/OllamaUtils.java
+++ b/test-suite-utils/src/main/java/io/micronaut/langchain4j/testutils/OllamaUtils.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.util.List;
 
 public final class OllamaUtils {
-    private static Logger LOG = LoggerFactory.getLogger(OllamaUtils.class);
+    private static final Logger LOG = LoggerFactory.getLogger(OllamaUtils.class);
     public static final String CHAT_MODEL_NAME = "tinyllama";
     public static final String TOOL_MODEL_NAME = "qwen2.5:0.5b";
     public static final String EMBEDDING_MODEL_NAME = "all-minilm";

--- a/test-suite-utils/src/main/java/io/micronaut/langchain4j/testutils/OllamaUtils.java
+++ b/test-suite-utils/src/main/java/io/micronaut/langchain4j/testutils/OllamaUtils.java
@@ -13,9 +13,11 @@ import java.util.List;
 
 public final class OllamaUtils {
     private static Logger LOG = LoggerFactory.getLogger(OllamaUtils.class);
-    private static String MODEL_NAME = "tinyllama";
-    private static String IMAGE_NAME = "ollama/ollama:latest";
-    private static String NEW_IMAGE_NAME = "ollama/ollama-tinyllama";
+    public static final String CHAT_MODEL_NAME = "tinyllama";
+    public static final String TOOL_MODEL_NAME = "qwen2.5:0.5b";
+    public static final String EMBEDDING_MODEL_NAME = "all-minilm";
+    private static final String IMAGE_NAME = "ollama/ollama:latest";
+    private static final String NEW_IMAGE_NAME = "ollama/ollama-tinyllama-qwen2.5-0.5b-all-minilm";
     private static OllamaContainer container;
 
     private OllamaUtils() {
@@ -35,6 +37,10 @@ public final class OllamaUtils {
         return String.format("http://%s:%d", container.getHost(), container.getFirstMappedPort());
     }
 
+    public static String ollamaEmbeddingModelName() {
+        return EMBEDDING_MODEL_NAME;
+    }
+
     private static void createAndStartContainer() throws InterruptedException, IOException {
         container = createContainer();
         container.start();
@@ -49,11 +55,11 @@ public final class OllamaUtils {
         DockerClient dockerClient = DockerClientFactory.lazyClient();
         List<Image> ollamaDockerImages = dockerClient
             .listImagesCmd()
-            .withImageNameFilter(NEW_IMAGE_NAME)
+            .withFilter("reference", List.of(NEW_IMAGE_NAME))
             .exec();
 
         if (ollamaDockerImages.isEmpty()) {
-            return createOllamaContainerAndPullModel(IMAGE_NAME, MODEL_NAME, NEW_IMAGE_NAME);
+            return createOllamaContainerAndPullModels(IMAGE_NAME, NEW_IMAGE_NAME, CHAT_MODEL_NAME, TOOL_MODEL_NAME, EMBEDDING_MODEL_NAME);
         } else {
             LOG.info("Using existing Ollama container with model image...");
             return new OllamaContainer(
@@ -61,12 +67,14 @@ public final class OllamaUtils {
         }
     }
 
-    private static OllamaContainer createOllamaContainerAndPullModel(String image, String model, String newImage) throws IOException, InterruptedException {
+    private static OllamaContainer createOllamaContainerAndPullModels(String image, String newImage, String... models) throws IOException, InterruptedException {
         LOG.info("Creating a new Ollama container...");
         OllamaContainer ollama = new OllamaContainer(image);
         ollama.start();
-        LOG.info("Executing an 'ollama pull' command...");
-        ollama.execInContainer("ollama", "pull", model);
+        for (String model : models) {
+            LOG.info("Executing an 'ollama pull' command for model '{}'...", model);
+            ollama.execInContainer("ollama", "pull", model);
+        }
         ollama.commitToImage(newImage);
         return ollama;
     }

--- a/test-suite/src/test/java/example/micronaut/aiservice/tools/OllamaToolTest.java
+++ b/test-suite/src/test/java/example/micronaut/aiservice/tools/OllamaToolTest.java
@@ -1,10 +1,10 @@
 package example.micronaut.aiservice.tools;
 
-import dev.langchain4j.exception.InvalidRequestException;
+import io.micronaut.context.annotation.Property;
 import io.micronaut.langchain4j.testutils.OllamaTestPropertyProvider;
+import io.micronaut.langchain4j.testutils.OllamaUtils;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @DisabledIfEnvironmentVariable(named = "CI", matches = ".*")
+@Property(name = "langchain4j.ollama.model-name", value = OllamaUtils.TOOL_MODEL_NAME)
 @Testcontainers(disabledWithoutDocker = true)
 @MicronautTest(startApplication = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -19,9 +20,7 @@ class OllamaToolTest implements OllamaTestPropertyProvider {
     @Test
     void testInjectTools(CompanyBot bot) {
         assertNotNull(bot);
-        InvalidRequestException e = assertThrows(InvalidRequestException.class, () ->
-            bot.ask("When was the PRIVACY document updated?")
-        );
-        assertTrue(e.getMessage().contains("does not support tools"), e.getMessage());
+        String response = bot.ask("When was the PRIVACY document updated?");
+        assertTrue(response.contains("2013"), response);
     }
 }


### PR DESCRIPTION
- Update to Langchain4j 1.5.1 SDK
- Cached Ollama image now includes tinyllama, qwen2.5:0.5b, and all-minilm.
- No longer overrides every Ollama test to use the tool-capable model; only sets the embedding model.
- Explicitly uses qwen2.5:0.5b because tinyllama does not support tools.
- Reduced Cassandra container memory settings to avoid OOMKilled.