### PR TITLE
Adding auto config to Oracle Chat Memory LangChain4j

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,8 +44,8 @@ jinjava = "2.8.3"
 tools-jackson-core = "3.1.4"
 
 # Managed versions appear in the BOM
-managed-langchain4j = "1.15.0"
-managed-langchain4j-community = "1.15.0-beta25"
+managed-langchain4j = "1.17.0"
+managed-langchain4j-community = "1.16.0-beta26"
 testcontainers-redis = "2.2.4"
 astra-db-client = "1.2.7"
 

--- a/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfiguration.java
+++ b/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfiguration.java
@@ -34,7 +34,7 @@ public interface OracleChatMemoryStoreConfiguration extends Toggleable {
     /**
      * OracleChatMemoryStore enabled configuration prefix.
      */
-    String PROPERTY_ENABLED = PREFIX + ".enabled";
+    String PROPERTY_ENABLED = PREFIX + ".default.enabled";
 
     @Override
     default boolean isEnabled() {

--- a/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfiguration.java
+++ b/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.langchain4j.oracle.memory;
+
+import dev.langchain4j.store.memory.chat.oracle.OracleChatMemoryStore;
+import io.micronaut.core.util.Toggleable;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Configuration for {@link dev.langchain4j.store.memory.chat.oracle.OracleChatMemoryStore.Builder}.
+ */
+public interface OracleChatMemoryStoreConfiguration extends Toggleable {
+    /**
+     * OracleChatMemoryStore configuration prefix.
+     */
+    String PREFIX = "langchain4j.chat-memory-store.oracle";
+    /**
+     * OracleChatMemoryStore default value for enabled.
+     */
+    boolean DEFAULT_ENABLED = true;
+    /**
+     * OracleChatMemoryStore enabled configuration prefix.
+     */
+    String PROPERTY_ENABLED = PREFIX + ".enabled";
+
+    @Override
+    default boolean isEnabled() {
+        return DEFAULT_ENABLED;
+    }
+
+    /**
+     * @return Oracle Chat Memory Store builder
+     */
+    OracleChatMemoryStore.@NonNull Builder getBuilder();
+}

--- a/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfigurationProperties.java
+++ b/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfigurationProperties.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.langchain4j.oracle.memory;
+
+import dev.langchain4j.store.memory.chat.oracle.OracleChatMemoryStore;
+import io.micronaut.context.annotation.ConfigurationBuilder;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * {@link ConfigurationProperties} implementation for {@link OracleChatMemoryStoreConfiguration}.
+ */
+@Internal
+@ConfigurationProperties(OracleChatMemoryStoreConfiguration.PREFIX)
+class OracleChatMemoryStoreConfigurationProperties implements OracleChatMemoryStoreConfiguration {
+    private boolean enabled = DEFAULT_ENABLED;
+
+    @ConfigurationBuilder(prefixes = "", excludes = "dataSource")
+    private OracleChatMemoryStore.@NonNull Builder builder = OracleChatMemoryStore.builder();
+
+    /**
+     * Whether Oracle ChatMemory store is enabled. Default value true
+     * @return Whether Oracle ChatMemory store is enabled. Default value true
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Whether Oracle ChatMemory store is enabled. Default value true
+     * @param enabled Whether Oracle ChatMemory store is enabled. Default value true
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    public OracleChatMemoryStore.@NonNull Builder getBuilder() {
+        return builder;
+    }
+
+    /**
+     * Oracle Chat Memory Store builder.
+     * @param builder Oracle Chat Memory Store builder
+     */
+    public void setBuilder(OracleChatMemoryStore.@NonNull Builder builder) {
+        this.builder = builder;
+    }
+}

--- a/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfigurationProperties.java
+++ b/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfigurationProperties.java
@@ -17,20 +17,28 @@ package io.micronaut.langchain4j.oracle.memory;
 
 import dev.langchain4j.store.memory.chat.oracle.OracleChatMemoryStore;
 import io.micronaut.context.annotation.ConfigurationBuilder;
-import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
 import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.NonNull;
 
+import javax.sql.DataSource;
+
 /**
- * {@link ConfigurationProperties} implementation for {@link OracleChatMemoryStoreConfiguration}.
+ * {@link EachProperty} implementation for {@link OracleChatMemoryStoreConfiguration}.
  */
 @Internal
-@ConfigurationProperties(OracleChatMemoryStoreConfiguration.PREFIX)
+@EachProperty(value = OracleChatMemoryStoreConfiguration.PREFIX, primary = "default")
 class OracleChatMemoryStoreConfigurationProperties implements OracleChatMemoryStoreConfiguration {
     private boolean enabled = DEFAULT_ENABLED;
 
     @ConfigurationBuilder(prefixes = "", excludes = "dataSource")
-    private OracleChatMemoryStore.@NonNull Builder builder = OracleChatMemoryStore.builder();
+    private OracleChatMemoryStore.@NonNull Builder builder;
+
+    OracleChatMemoryStoreConfigurationProperties(@Parameter DataSource dataSource) {
+        this.builder = OracleChatMemoryStore.builder()
+            .dataSource(dataSource);
+    }
 
     /**
      * Whether Oracle ChatMemory store is enabled. Default value true

--- a/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreFactory.java
+++ b/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreFactory.java
@@ -20,18 +20,15 @@ import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.core.annotation.Internal;
-import jakarta.inject.Named;
 import jakarta.inject.Singleton;
-
-import javax.sql.DataSource;
 
 @Factory
 @Internal
 class OracleChatMemoryStoreFactory {
-    @Named("oracle")
     @Prototype
-    OracleChatMemoryStore.Builder createOracleChatMemoryStoreBuilder(OracleChatMemoryStoreConfiguration config, DataSource dataSource) {
-        return config.getBuilder().dataSource(dataSource);
+    @EachBean(OracleChatMemoryStoreConfigurationProperties.class)
+    OracleChatMemoryStore.Builder createOracleChatMemoryStoreBuilder(OracleChatMemoryStoreConfiguration config) {
+        return config.getBuilder();
     }
 
     @Singleton

--- a/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreFactory.java
+++ b/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.langchain4j.oracle.memory;
+
+import dev.langchain4j.store.memory.chat.oracle.OracleChatMemoryStore;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.core.annotation.Internal;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import javax.sql.DataSource;
+
+@Factory
+@Internal
+class OracleChatMemoryStoreFactory {
+    @Named("oracle")
+    @Prototype
+    OracleChatMemoryStore.Builder createOracleChatMemoryStoreBuilder(OracleChatMemoryStoreConfiguration config, DataSource dataSource) {
+        return config.getBuilder().dataSource(dataSource);
+    }
+
+    @Singleton
+    @EachBean(OracleChatMemoryStore.Builder.class)
+    OracleChatMemoryStore createOracleChatMemoryStore(OracleChatMemoryStore.Builder builder) {
+        return builder.build();
+    }
+}

--- a/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreFactory.java
+++ b/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreFactory.java
@@ -19,6 +19,7 @@ import dev.langchain4j.store.memory.chat.oracle.OracleChatMemoryStore;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.exceptions.DisabledBeanException;
 import io.micronaut.core.annotation.Internal;
 import jakarta.inject.Singleton;
 
@@ -28,6 +29,9 @@ class OracleChatMemoryStoreFactory {
     @Prototype
     @EachBean(OracleChatMemoryStoreConfigurationProperties.class)
     OracleChatMemoryStore.Builder createOracleChatMemoryStoreBuilder(OracleChatMemoryStoreConfiguration config) {
+        if (!config.isEnabled()) {
+            throw new DisabledBeanException("enabled is set to false");
+        }
         return config.getBuilder();
     }
 

--- a/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/package-info.java
+++ b/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/package-info.java
@@ -17,7 +17,7 @@
  * Oracle {@link dev.langchain4j.store.memory.chat.ChatMemoryStore} implementation related classes.
  */
 @Configuration
-@Requires(property = OracleChatMemoryStoreConfiguration.PREFIX)
+@Requires(property = OracleChatMemoryStoreConfiguration.PROPERTY_ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
 @Requires(classes = OracleChatMemoryStore.class)
 @Requires(beans = DataSource.class)
 package io.micronaut.langchain4j.oracle.memory;
@@ -25,5 +25,6 @@ package io.micronaut.langchain4j.oracle.memory;
 import dev.langchain4j.store.memory.chat.oracle.OracleChatMemoryStore;
 import io.micronaut.context.annotation.Configuration;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
 
 import javax.sql.DataSource;

--- a/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/package-info.java
+++ b/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/package-info.java
@@ -17,7 +17,7 @@
  * Oracle {@link dev.langchain4j.store.memory.chat.ChatMemoryStore} implementation related classes.
  */
 @Configuration
-@Requires(property = OracleChatMemoryStoreConfiguration.PROPERTY_ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+@Requires(property = OracleChatMemoryStoreConfiguration.PREFIX)
 @Requires(classes = OracleChatMemoryStore.class)
 @Requires(beans = DataSource.class)
 package io.micronaut.langchain4j.oracle.memory;
@@ -25,6 +25,5 @@ package io.micronaut.langchain4j.oracle.memory;
 import dev.langchain4j.store.memory.chat.oracle.OracleChatMemoryStore;
 import io.micronaut.context.annotation.Configuration;
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.util.StringUtils;
 
 import javax.sql.DataSource;

--- a/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/package-info.java
+++ b/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Oracle {@link dev.langchain4j.store.memory.chat.ChatMemoryStore} implementation related classes.
+ */
+@Configuration
+@Requires(property = OracleChatMemoryStoreConfiguration.PROPERTY_ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+@Requires(classes = OracleChatMemoryStore.class)
+@Requires(beans = DataSource.class)
+package io.micronaut.langchain4j.oracle.memory;
+
+import dev.langchain4j.store.memory.chat.oracle.OracleChatMemoryStore;
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+
+import javax.sql.DataSource;

--- a/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/package-info.java
+++ b/micronaut-langchain4j-store-oracle/src/main/java/io/micronaut/langchain4j/oracle/memory/package-info.java
@@ -17,7 +17,7 @@
  * Oracle {@link dev.langchain4j.store.memory.chat.ChatMemoryStore} implementation related classes.
  */
 @Configuration
-@Requires(property = OracleChatMemoryStoreConfiguration.PROPERTY_ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+@Requires(property = OracleChatMemoryStoreConfiguration.PREFIX + ".default.enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
 @Requires(classes = OracleChatMemoryStore.class)
 @Requires(beans = DataSource.class)
 package io.micronaut.langchain4j.oracle.memory;

--- a/micronaut-langchain4j-store-oracle/src/test/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfigurationTest.java
+++ b/micronaut-langchain4j-store-oracle/src/test/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfigurationTest.java
@@ -30,13 +30,11 @@ class OracleChatMemoryStoreConfigurationTest {
         assertNotNull(chatMemoryStore);
     }
 
-    @Property(name = "langchain4j.chat-memory-store.oracle.reporting.enabled", value = StringUtils.FALSE)
+    @Property(name = "langchain4j.chat-memory-store.oracle.default.enabled", value = StringUtils.FALSE)
     @Test
     void disabledOracleChatMemoryConfigurationDoesNotCreateStore() {
-        assertTrue(beanContext.containsBean(OracleChatMemoryStore.class, Qualifiers.byName("default")));
-        assertTrue(beanContext.containsBean(OracleChatMemoryStoreConfiguration.class, Qualifiers.byName("reporting")));
         assertTrue(beanContext.containsBean(OracleChatMemoryStoreConfiguration.class, Qualifiers.byName("default")));
-        assertFalse(beanContext.getBean(OracleChatMemoryStoreConfiguration.class, Qualifiers.byName("reporting")).isEnabled());
-        assertFalse(beanContext.containsBean(OracleChatMemoryStore.class, Qualifiers.byName("reporting")));
+        assertFalse(beanContext.getBean(OracleChatMemoryStoreConfiguration.class, Qualifiers.byName("default")).isEnabled());
+        assertFalse(beanContext.containsBean(OracleChatMemoryStore.class, Qualifiers.byName("default")));
     }
 }

--- a/micronaut-langchain4j-store-oracle/src/test/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfigurationTest.java
+++ b/micronaut-langchain4j-store-oracle/src/test/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfigurationTest.java
@@ -1,24 +1,25 @@
 package io.micronaut.langchain4j.oracle.memory;
 
 import dev.langchain4j.store.memory.chat.oracle.OracleChatMemoryStore;
-import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Named;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Property(name = "langchain4j.ollama.enabled", value = StringUtils.FALSE)
+@Property(name = "langchain4j.chat-memory-store.oracle.default.enabled", value = StringUtils.TRUE)
 @MicronautTest(startApplication = false)
 class OracleChatMemoryStoreConfigurationTest {
 
     @Test
-    void oracleChatMemoryConfiguration() {
-        try (ApplicationContext applicationContext = ApplicationContext.run()) {
-            OracleChatMemoryStoreConfiguration config = applicationContext.getBean(OracleChatMemoryStoreConfiguration.class);
-            assertTrue(config.isEnabled());
-            assertNotNull(config.getBuilder());
-        }
+    void oracleChatMemoryConfiguration(@Named("default") OracleChatMemoryStoreConfiguration config,
+                                       @Named("default") OracleChatMemoryStore chatMemoryStore) {
+        assertTrue(config.isEnabled());
+        assertNotNull(config.getBuilder());
+        assertNotNull(chatMemoryStore);
     }
 }

--- a/micronaut-langchain4j-store-oracle/src/test/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfigurationTest.java
+++ b/micronaut-langchain4j-store-oracle/src/test/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfigurationTest.java
@@ -1,0 +1,24 @@
+package io.micronaut.langchain4j.oracle.memory;
+
+import dev.langchain4j.store.memory.chat.oracle.OracleChatMemoryStore;
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Property(name = "langchain4j.ollama.enabled", value = StringUtils.FALSE)
+@MicronautTest(startApplication = false)
+class OracleChatMemoryStoreConfigurationTest {
+
+    @Test
+    void oracleChatMemoryConfiguration() {
+        try (ApplicationContext applicationContext = ApplicationContext.run()) {
+            OracleChatMemoryStoreConfiguration config = applicationContext.getBean(OracleChatMemoryStoreConfiguration.class);
+            assertTrue(config.isEnabled());
+            assertNotNull(config.getBuilder());
+        }
+    }
+}

--- a/micronaut-langchain4j-store-oracle/src/test/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfigurationTest.java
+++ b/micronaut-langchain4j-store-oracle/src/test/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfigurationTest.java
@@ -6,6 +6,7 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import org.junit.jupiter.api.Test;
 
@@ -18,6 +19,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 @MicronautTest(startApplication = false)
 class OracleChatMemoryStoreConfigurationTest {
 
+    @Inject
+    BeanContext beanContext;
+
     @Test
     void oracleChatMemoryConfiguration(@Named("default") OracleChatMemoryStoreConfiguration config,
                                        @Named("default") OracleChatMemoryStore chatMemoryStore) {
@@ -28,7 +32,7 @@ class OracleChatMemoryStoreConfigurationTest {
 
     @Property(name = "langchain4j.chat-memory-store.oracle.reporting.enabled", value = StringUtils.FALSE)
     @Test
-    void disabledOracleChatMemoryConfigurationDoesNotCreateStore(BeanContext beanContext) {
+    void disabledOracleChatMemoryConfigurationDoesNotCreateStore() {
         assertTrue(beanContext.containsBean(OracleChatMemoryStore.class, Qualifiers.byName("default")));
         assertTrue(beanContext.containsBean(OracleChatMemoryStoreConfiguration.class, Qualifiers.byName("reporting")));
         assertTrue(beanContext.containsBean(OracleChatMemoryStoreConfiguration.class, Qualifiers.byName("default")));

--- a/micronaut-langchain4j-store-oracle/src/test/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfigurationTest.java
+++ b/micronaut-langchain4j-store-oracle/src/test/java/io/micronaut/langchain4j/oracle/memory/OracleChatMemoryStoreConfigurationTest.java
@@ -1,14 +1,17 @@
 package io.micronaut.langchain4j.oracle.memory;
 
 import dev.langchain4j.store.memory.chat.oracle.OracleChatMemoryStore;
+import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Named;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @Property(name = "langchain4j.ollama.enabled", value = StringUtils.FALSE)
 @Property(name = "langchain4j.chat-memory-store.oracle.default.enabled", value = StringUtils.TRUE)
@@ -21,5 +24,15 @@ class OracleChatMemoryStoreConfigurationTest {
         assertTrue(config.isEnabled());
         assertNotNull(config.getBuilder());
         assertNotNull(chatMemoryStore);
+    }
+
+    @Property(name = "langchain4j.chat-memory-store.oracle.reporting.enabled", value = StringUtils.FALSE)
+    @Test
+    void disabledOracleChatMemoryConfigurationDoesNotCreateStore(BeanContext beanContext) {
+        assertTrue(beanContext.containsBean(OracleChatMemoryStore.class, Qualifiers.byName("default")));
+        assertTrue(beanContext.containsBean(OracleChatMemoryStoreConfiguration.class, Qualifiers.byName("reporting")));
+        assertTrue(beanContext.containsBean(OracleChatMemoryStoreConfiguration.class, Qualifiers.byName("default")));
+        assertFalse(beanContext.getBean(OracleChatMemoryStoreConfiguration.class, Qualifiers.byName("reporting")).isEnabled());
+        assertFalse(beanContext.containsBean(OracleChatMemoryStore.class, Qualifiers.byName("reporting")));
     }
 }

--- a/src/main/docs/guide/chatModels/chatMemory.adoc
+++ b/src/main/docs/guide/chatModels/chatMemory.adoc
@@ -27,11 +27,17 @@ Then configure a JDBC datasource and the chat memory store properties, for examp
 [configuration]
 ----
 datasources.default.dialect: oracle
-langchain4j.chat-memory-store.oracle.enabled: true
-langchain4j.chat-memory-store.oracle.table-name: CHAT_MEMORY
+langchain4j.chat-memory-store.oracle.default.enabled: true
+langchain4j.chat-memory-store.oracle.default.table-name: CHAT_MEMORY
+langchain4j.chat-memory-store.oracle.default.memory-id-column-name: MEMORY_ID
+langchain4j.chat-memory-store.oracle.default.content-column-name: CONTENT
 ----
 
 The table must already exist. By default, the expected schema is `CHAT_MEMORY(MEMORY_ID, CONTENT)`.
+
+The segment under `oracle` (for example `default`) maps to the datasource name.
+For multiple datasources, configure multiple entries such as
+`langchain4j.chat-memory-store.oracle.reporting.*`.
 
 The following example shows how to use the `ChatMemory`:
 

--- a/src/main/docs/guide/chatModels/chatMemory.adoc
+++ b/src/main/docs/guide/chatModels/chatMemory.adoc
@@ -18,6 +18,21 @@ To use the Cassandra implementation `dev.langchain4j.store.memory.chat.cassandra
 
 dependency:micronaut-langchain4j-cassandra[groupId=io.micronaut.langchain4j]
 
+To use the Oracle implementation `dev.langchain4j.store.memory.chat.oracle.OracleChatMemoryStore`, add the following dependency:
+
+dependency:micronaut-langchain4j-store-oracle[groupId=io.micronaut.langchain4j]
+
+Then configure a JDBC datasource and the chat memory store properties, for example:
+
+[configuration]
+----
+datasources.default.dialect: oracle
+langchain4j.chat-memory-store.oracle.enabled: true
+langchain4j.chat-memory-store.oracle.table-name: CHAT_MEMORY
+----
+
+The table must already exist. By default, the expected schema is `CHAT_MEMORY(MEMORY_ID, CONTENT)`.
+
 The following example shows how to use the `ChatMemory`:
 
 snippet::example.micronaut.AssistantWithMemory[source=main]


### PR DESCRIPTION
This PR depends on https://github.com/langchain4j/langchain4j/pull/5351 which adds Oracle Chat Memory to LangChain4j (we added the Oracle Embedding Store). Creating this draft PR to get feedback.